### PR TITLE
Colour list items based on unit status

### DIFF
--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -27,6 +27,14 @@ impl UnitStatus {
     self.active_state == "active"
   }
 
+  pub fn is_failed(&self) -> bool {
+    self.active_state == "failed"
+  }
+
+  pub fn is_not_found(&self) -> bool {
+    self.load_state == "not-found"
+  }
+
   pub fn is_enabled(&self) -> bool {
     self.load_state == "loaded" && self.active_state == "active"
   }


### PR DESCRIPTION
This PR colours units in the list based on their status. I attempted to follow the same logic that sysz does (see comment for more info). Closes #9 

![image](https://github.com/rgwood/systemctl-tui/assets/26268125/e432b4af-c609-4f70-908f-54bf42473fa3)
