### PR TITLE
Fix failure to launch when running as root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1705,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "nix 0.27.1",
  "ratatui",
  "signal-hook",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ indexmap = "2.0.0"
 clipboard-anywhere = "0.2.2"
 chrono = { version = "0.4.31", default-features = false }
 lazy_static = "1.4.0"
+nix = { version = "0.27.1", features = ["user"] }
 
 # build with `cargo build --profile profiling`
 # to analyze performance with tooling like perf / samply / superluminal


### PR DESCRIPTION
The recent change to pull in user services had an unfortunate consequence: we now crash on launch when running as `root` (which has no user services).

As a fix, log the error and continue if we're running as root.