### PR TITLE
Add option to limit view to certain units

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,7 @@ pub struct App {
 }
 
 impl App {
-  pub fn new(scope: Scope, limit_units : Vec<String>) -> Result<Self> {
+  pub fn new(scope: Scope, limit_units: Vec<String>) -> Result<Self> {
     let home = Home::new(scope, &limit_units);
     let home = Arc::new(Mutex::new(home));
     Ok(Self { scope, home, limit_units, should_quit: false, should_suspend: false })

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,15 +15,16 @@ use crate::{
 pub struct App {
   pub scope: Scope,
   pub home: Arc<Mutex<Home>>,
+  pub limit_units: Vec<String>,
   pub should_quit: bool,
   pub should_suspend: bool,
 }
 
 impl App {
-  pub fn new(scope: Scope) -> Result<Self> {
-    let home = Home::new(scope);
+  pub fn new(scope: Scope, limit_units : Vec<String>) -> Result<Self> {
+    let home = Home::new(scope, &limit_units);
     let home = Arc::new(Mutex::new(home));
-    Ok(Self { scope, home, should_quit: false, should_suspend: false })
+    Ok(Self { scope, home, limit_units, should_quit: false, should_suspend: false })
   }
 
   pub async fn run(&mut self) -> Result<()> {
@@ -57,7 +58,7 @@ impl App {
 
     self.home.lock().await.init(action_tx.clone())?;
 
-    let units = get_all_services(self.scope)
+    let units = get_all_services(self.scope, &self.limit_units)
       .await
       .context("Unable to get services. Check that systemd is running and try running this tool with sudo.")?;
     self.home.lock().await.set_units(units);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,9 @@ struct Args {
   /// Enable performance tracing (in Chromium Event JSON format)
   #[clap(short, long)]
   trace: bool,
+  /// Limit view to only these unit files
+  #[clap(short, long, default_value="*.service", num_args=0..)]
+  limit_units: Vec<String>,
 }
 
 #[derive(Parser, Debug, ValueEnum, Clone)]
@@ -52,7 +55,7 @@ async fn main() -> Result<()> {
     },
   };
 
-  let mut app = App::new(scope)?;
+  let mut app = App::new(scope, args.limit_units)?;
   app.run().await?;
 
   Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ struct Args {
   #[clap(short, long)]
   trace: bool,
   /// Limit view to only these unit files
-  #[clap(short, long, default_value="*.service", num_args=0..)]
+  #[clap(short, long, default_value="*.service", num_args=1..)]
   limit_units: Vec<String>,
 }
 

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -114,7 +114,8 @@ pub async fn get_all_services(scope: Scope, services: &[String]) -> Result<Vec<U
       units.extend(user_units);
     },
     Scope::All => {
-      let (system_units, user_units) = tokio::join!(get_services(UnitScope::Global, services), get_services(UnitScope::User, services));
+      let (system_units, user_units) =
+        tokio::join!(get_services(UnitScope::Global, services), get_services(UnitScope::User, services));
       units.extend(system_units?);
 
       // Should always be able to get user units, but it may fail when running as root

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -97,7 +97,7 @@ pub enum Scope {
 }
 
 // this takes like 5-10 ms on 13th gen Intel i7 (scope=all)
-pub async fn get_all_services(scope: Scope) -> Result<Vec<UnitWithStatus>> {
+pub async fn get_all_services(scope: Scope, services: &[String]) -> Result<Vec<UnitWithStatus>> {
   let start = std::time::Instant::now();
 
   let mut units = vec![];
@@ -106,15 +106,15 @@ pub async fn get_all_services(scope: Scope) -> Result<Vec<UnitWithStatus>> {
 
   match scope {
     Scope::Global => {
-      let system_units = get_services(UnitScope::Global).await?;
+      let system_units = get_services(UnitScope::Global, services).await?;
       units.extend(system_units);
     },
     Scope::User => {
-      let user_units = get_services(UnitScope::User).await?;
+      let user_units = get_services(UnitScope::User, services).await?;
       units.extend(user_units);
     },
     Scope::All => {
-      let (system_units, user_units) = tokio::join!(get_services(UnitScope::Global), get_services(UnitScope::User));
+      let (system_units, user_units) = tokio::join!(get_services(UnitScope::Global, services), get_services(UnitScope::User, services));
       units.extend(system_units?);
 
       // Should always be able to get user units, but it may fail when running as root
@@ -136,10 +136,10 @@ pub async fn get_all_services(scope: Scope) -> Result<Vec<UnitWithStatus>> {
   Ok(units)
 }
 
-async fn get_services(scope: UnitScope) -> Result<Vec<UnitWithStatus>, anyhow::Error> {
+async fn get_services(scope: UnitScope, services: &[String]) -> Result<Vec<UnitWithStatus>, anyhow::Error> {
   let connection = get_connection(scope).await?;
   let manager_proxy = ManagerProxy::new(&connection).await?;
-  let units = manager_proxy.list_units_by_patterns(vec![], vec!["*.service".into()]).await?;
+  let units = manager_proxy.list_units_by_patterns(vec![], services.to_vec()).await?;
   let units: Vec<_> = units.into_iter().map(|u| to_unit_status(u, scope)).collect();
   Ok(units)
 }


### PR DESCRIPTION
Hi, I've had an itch to have an overview for some application consisting of over a dozen unit files, so I've searched for something like this. I'm just submitting this as a draft so you or others can have look to see if it's interesting.

This allows a user to limit the view to certain units, which makes it usable as a simple service front end for complex services:
```
systemctl-tui --limit-units abc\*.{service,timer} bce.service
```
This also allows one to show other unit types besides just `.service`. The UI doesn't support those, of course, but it seems to work fine with timers for now. And didn't even crash for `.mount`.

**Caveats**:
Other unit types besides `service` aren't fully supported by the rest of the app.
Maybe using a short option for such a niche use case isn't really necessary. 
Also I'm a complete newbie in Rust, so this may leak memory or other fluids.
