### PR TITLE
Support terminals with light background

### DIFF
--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -711,7 +711,7 @@ impl Component for Home {
       } else if unit.is_not_found() {
         Color::Yellow
       } else {
-        Color::White
+        Color::Reset
       }
     }
 
@@ -777,14 +777,14 @@ impl Component for Home {
         "loaded" => Color::Green,
         "not-found" => Color::Yellow,
         "error" => Color::Red,
-        _ => Color::White,
+        _ => Color::Reset,
       };
 
       let active_color = match i.activation_state.as_str() {
         "active" => Color::Green,
         "inactive" => Color::Gray,
         "failed" => Color::Red,
-        _ => Color::White,
+        _ => Color::Reset,
       };
 
       let active_state_value = format!("{} ({})", i.activation_state, i.sub_state);
@@ -795,8 +795,8 @@ impl Component for Home {
       };
 
       let mut lines = vec![
-        colored_line(&i.description, Color::White),
-        colored_line(scope, Color::White),
+        colored_line(&i.description, Color::Reset),
+        colored_line(scope, Color::Reset),
         colored_line(&i.load_state, load_color),
         line_color_string(active_state_value, active_color),
       ];


### PR DESCRIPTION
In terminals with a light background, white text is very hard or even impossible to read.
This revision changes white text to "reset", which is a pseudo-color that resets to the default colors.

An alternative approach could be to use https://github.com/Canop/terminal-light to check the terminal background luma and determine a suitable default text color from that,
but since we're not styling the terminal background the reset approach seemed more straightforward.
