### PR TITLE
Add install/update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,18 @@ A fast, simple TUI for interacting with [systemd](https://en.wikipedia.org/wiki/
 
 ## Install
 
-Note: this project only works on Linux (WSL works _if_ you [have systemd enabled](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/)). Binaries are published for x64 and ARM64 in the GitHub releases, and [distro packages](#distro-packages) are available.
+Note: this project only works on Linux (WSL works _if_ you [have systemd enabled](https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/)). Binaries are published for x64 and ARM64 in the [GitHub releases](https://github.com/rgwood/systemctl-tui/releases), and [distro packages](#distro-packages) are available.
+
+### Binary Release
+
+Automated install/update (don't forget to always verify what you're piping into bash):
+
+```sh
+curl https://raw.githubusercontent.com/rgwood/systemctl-tui/master/install.sh | bash
+```
+The script installs downloaded binary to `$HOME/.local/bin` directory by default, but it can be changed by setting `DIR` environment variable.
+
+### Rust
 
 If you'd rather build from scratch you will need [Rust installed](https://rustup.rs/). Then either:
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# allow specifying different destination directory
+DIR="${DIR:-"$HOME/.local/bin"}"
+
+# map different architecture variations to the available binaries
+ARCH=$(uname -m)
+case $ARCH in
+    i386|i686) ARCH=x86 ;;
+    aarch64*) ARCH=arm64 ;;
+esac
+
+# prepare the download URL
+GITHUB_LATEST_VERSION=$(curl -L -s -H 'Accept: application/json' https://github.com/rgwood/systemctl-tui/releases/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+GITHUB_FILE="systemctl-tui-${ARCH}-unknown-linux-musl.tar.gz"
+GITHUB_URL="https://github.com/rgwood/systemctl-tui/releases/download/${GITHUB_LATEST_VERSION}/${GITHUB_FILE}"
+
+# install/update the local binary
+curl -L -o systemctl-tui.tar.gz $GITHUB_URL
+tar xzvf systemctl-tui.tar.gz systemctl-tui
+install -Dm 755 systemctl-tui -t "$DIR"
+rm systemctl-tui systemctl-tui.tar.gz


### PR DESCRIPTION
I adapted the install/update script from [lazydocker](https://github.com/jesseduffield/lazydocker). It downloads the latest version from github for the desired architecture, unzips, installs the application, and then deletes the archive. Should work on all distributions. Also made changes in readme about this installation method.