### PR TITLE
Support light terminal themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,7 +641,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2173,6 +2179,7 @@ dependencies = [
  "nix 0.30.1",
  "ratatui 0.29.0",
  "signal-hook",
+ "terminal-light",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2195,6 +2202,18 @@ dependencies = [
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal-light"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f76be906d875a0ce764c52a055858c24847cb7dc674d3a5ad8cf7e3dd4ee9f"
+dependencies = [
+ "coolor",
+ "crossterm 0.29.0",
+ "thiserror 1.0.69",
+ "xterm-query",
 ]
 
 [[package]]
@@ -3117,6 +3136,16 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "xterm-query"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292c33df434fde4ecd87a7afecdfa1681a3d29567fc69c774a0d83d32c095331"
+dependencies = [
+ "nix 0.29.0",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "zbus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ lazy_static = "1.4.0"
 nix = { version = "0.30.1", features = ["user"] }
 is-wsl = "0.4.0"
 tracing-appender = "0.2.3"
+terminal-light = "1"
 
 # build with `cargo build --profile profiling`
 # to analyze performance with tooling like perf / samply / superluminal


### PR DESCRIPTION
## Summary
- Detect terminal background color at startup using the `terminal-light` crate
- Select appropriate color palettes based on detected theme
- Dark terminals get the original colors (Cyan, LightGreen, Gray)
- Light terminals get readable alternatives (Blue, Green, DarkGray)

Fixes #59

<img width="2219" height="621" alt="image" src="https://github.com/user-attachments/assets/e2be1a7d-ede2-4943-a757-2e2920494488" />
