### PR TITLE
Add follow-logs action via journalctl

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -38,5 +38,6 @@ pub enum Action {
   ScrollToBottom,
   EditUnitFile { unit: UnitId, path: String },
   OpenLogsInPager { logs: Vec<String> },
+  FollowLogs(UnitId),
   Noop,
 }

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -656,6 +656,13 @@ impl Component for Home {
           KeyCode::Char('o') => {
             vec![Action::OpenLogsInPager { logs: self.logs.clone() }]
           },
+          KeyCode::Char('l') => {
+            if let Some(selected) = self.filtered_units.selected() {
+              vec![Action::FollowLogs(selected.unit.id())]
+            } else {
+              vec![]
+            }
+          },
           KeyCode::Enter | KeyCode::Char(' ') => vec![Action::EnterMode(Mode::ActionMenu)],
           _ => vec![],
         }
@@ -1198,6 +1205,7 @@ impl Component for Home {
         Line::from(""),
         Line::from(vec![primary("ctrl+C"), Span::raw(" or "), primary("ctrl+Q"), Span::raw(" to quit")]),
         Line::from(vec![primary("ctrl+L"), Span::raw(" toggles the logger pane")]),
+        Line::from(vec![primary("l"), Span::raw(" follow logs via journalctl")]),
         Line::from(vec![primary("PageUp"), Span::raw(" / "), primary("PageDown"), Span::raw(" scroll the logs")]),
         Line::from(vec![primary("Home"), Span::raw(" / "), primary("End"), Span::raw(" scroll to top/bottom")]),
         Line::from(vec![primary("Enter"), Span::raw(" or "), primary("Space"), Span::raw(" open the action menu")]),
@@ -1258,7 +1266,10 @@ impl Component for Home {
     let help_line = match self.mode {
       Mode::Search => Line::from(span("Show actions: <enter>", theme.primary)),
       Mode::ServiceList => {
-        Line::from(span("Show actions: <enter> | Open logs in pager: o | Edit unit file: e | Quit: q", theme.primary))
+        Line::from(span(
+          "Show actions: <enter> | Follow logs: l | Open logs in pager: o | Edit unit file: e | Quit: q",
+          theme.primary,
+        ))
       },
       Mode::Help => Line::from(span("Close menu: <esc>", theme.primary)),
       Mode::ActionMenu => Line::from(span("Execute action: <enter> | Close menu: <esc>", theme.primary)),


### PR DESCRIPTION
This PR adds a “follow logs” workflow from the service list so you can tail a unit’s journal output directly from the TUI. It wires a new action, keybinding, and help text, then temporarily exits the TUI to run journalctl -f (using sudo for system scope or --user for user scope) and returns cleanly to the app afterward.

  Changes:

  - Add a new Action::FollowLogs(UnitId) to represent the follow-logs flow.
  - Handle follow-logs in App by stopping the event loop, exiting the TUI, running
    journalctl -u <unit> -f, and re-entering the TUI afterward, reinitializing the event
    handler and returning to the service list.
  - Bind l in the service list to follow the selected unit’s logs.
  - Update help text and the help pane to document the new shortcut.

  Testing:

  - Not run (not requested).

  Notes:

  - System-scope units run sudo journalctl -u <unit> -f.
  - User-scope units run journalctl --user -u <unit> -f.
