### PR TITLE
Add favorites section with persistence and focused navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,6 +1984,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2201,8 @@ dependencies = [
  "log",
  "nix 0.30.1",
  "ratatui 0.29.0",
+ "serde",
+ "serde_yaml",
  "signal-hook",
  "terminal-light",
  "tokio",
@@ -2618,6 +2633,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ nix = { version = "0.30.1", features = ["user"] }
 is-wsl = "0.4.0"
 tracing-appender = "0.2.3"
 terminal-light = "1"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_yaml = "0.9.34"
 
 # build with `cargo build --profile profiling`
 # to analyze performance with tooling like perf / samply / superluminal

--- a/src/action.rs
+++ b/src/action.rs
@@ -38,5 +38,6 @@ pub enum Action {
   ScrollToBottom,
   EditUnitFile { unit: UnitId, path: String },
   OpenLogsInPager { logs: Vec<String> },
+  ToggleFavorite(UnitId),
   Noop,
 }

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -5,11 +5,12 @@ use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 use log::error;
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use zbus::{proxy, zvariant, Connection};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UnitWithStatus {
   pub name: String,                              // The primary unit name as string
   pub scope: UnitScope,                          // System or user?
@@ -35,14 +36,14 @@ pub struct UnitWithStatus {
   // pub job_path: String, // The job object path
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UnitScope {
   Global,
   User,
 }
 
 /// Just enough info to fully identify a unit
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct UnitId {
   pub name: String,
   pub scope: UnitScope,


### PR DESCRIPTION
This PR introduces a Favorites section above Services so commonly used units can be surfaced and navigated quickly. Services can be favorites with a shortcut, persisted to `~/.config/systemctl-tui.yaml`, and rendered in a dedicated list only when favorites exist. Navigation gains list focus (Favorites vs Services) with Tab/Shift+Tab and direct focus shortcuts (1/2), plus directional behavior to move between lists. Help and headings are updated to reflect the new shortcuts and config path.

  Changes:

  - Add favorites persistence via YAML config at ~/.config/systemctl-tui.yaml.
  - Introduce favorites state in Home and load/save on toggle.
  - Render a Favorites list above Services only when favorites are present, with its own
    selection state.
  - Enforce a minimum Services height to show at least 5 items when Favorites are
    visible.
  - Add list focus state and navigation:
      - Tab/Shift+Tab toggles focus between Favorites and Services.
      - 1 focuses Favorites; 2 focuses Services.
      - Up/Down moves across lists at boundaries (Services top → Favorites; Favorites
        bottom → Services).
  - Update help text and headings to document shortcuts and show the config file path in
    the footer help line.

 Testing:
<img width="1460" height="841" alt="Screenshot 2026-01-22 at 4 48 32 PM" src="https://github.com/user-attachments/assets/e094eee1-399f-4dbd-99f9-c41c74a6cec0" />

  Notes:
  - Favorites are grouped at the top of the filtered list to keep selection/scrolling
    consistent with split rendering.
  - If no favorites exist, only the Services list is shown and focus defaults to
    Services.
