### PR TITLE
Fix misleading "no logs" message when journal access is permission-restricted

### DIFF
--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -683,9 +683,12 @@ impl LogDiagnostic {
         format!("Cannot access journal: {} (check that systemd-journald is running)", error)
       },
       Self::PermissionDenied { error } => format!(
-        "Permission denied accessing journal. Add your user to the 'systemd-journal' group \
-         (sudo usermod -aG systemd-journal $USER, then re-login) or run with sudo systemctl-tui. \
-         (journalctl: {})",
+        concat!(
+          "Permission denied accessing journal. ",
+          "Add your user to the 'systemd-journal' group ",
+          "(sudo usermod -aG systemd-journal $USER, then re-login) ",
+          "or run with sudo systemctl-tui. (journalctl: {})"
+        ),
         error
       ),
       Self::NoLogsRecorded { unit_name } => {

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -678,7 +678,12 @@ impl LogDiagnostic {
       Self::JournalInaccessible { error } => {
         format!("Cannot access journal: {}\n\nCheck that systemd-journald is running", error)
       },
-      Self::PermissionDenied { error } => format!("Permission denied: {}\n\nTry: sudo systemctl-tui", error),
+      Self::PermissionDenied { error } => format!(
+        "Permission denied accessing journal:\n{}\n\nTry one of:\n  \
+         - Add your user to the 'systemd-journal' group: sudo usermod -aG systemd-journal $USER (then re-login)\n  \
+         - Run with sudo: sudo systemctl-tui",
+        error
+      ),
       Self::NoLogsRecorded { unit_name } => {
         format!("No logs recorded for {} (unit has run but produced no journal output)", unit_name)
       },
@@ -706,19 +711,46 @@ pub fn check_unit_has_run(unit: &UnitId) -> bool {
     .unwrap_or(false)
 }
 
-/// Check if the journal is accessible at all (tests general read access)
+/// Returns true if a `journalctl` error/warning message indicates a
+/// permission-related issue.
+///
+/// Covers both:
+/// - Hard failures (exit ≠ 0): `Permission denied`, `Access denied`,
+///   `No journal files were opened due to insufficient permissions.`
+/// - Soft failures (exit 0 with stderr): `Warning: some journal files were
+///   not opened due to insufficient permissions.`, and the `Hint:` notice
+///   shown when the user is missing from the adm/systemd-journal/wheel
+///   groups (`Users in groups '...' can see all messages.`).
+fn is_permission_error(message: &str) -> bool {
+  let s = message.to_lowercase();
+  s.contains("insufficient permissions")
+    || s.contains("not opened")
+    || s.contains("permission denied")
+    || s.contains("access denied")
+    || s.contains("can see all messages")
+}
+
+/// Check if the journal is accessible at all (tests general read access).
+///
+/// Note: deliberately does NOT pass `--quiet`. Per `man journalctl`, `--quiet`
+/// suppresses "warning messages regarding inaccessible system journal files",
+/// which is exactly the signal we need to surface to the user. Even when
+/// `journalctl` exits 0 (because at least one journal file is readable), a
+/// permission warning on stderr means the view is incomplete and we should
+/// treat it as a failure so callers can route through `parse_journalctl_error`.
 fn can_access_journal(scope: UnitScope) -> Result<(), String> {
-  let mut args = vec!["--lines=1", "--quiet"];
+  let mut args = vec!["--lines=1"];
   if scope == UnitScope::User {
     args.push("--user");
   }
 
   match Command::new("journalctl").args(&args).output() {
     Ok(output) => {
-      if output.status.success() {
-        Ok(())
+      let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+      if !output.status.success() || is_permission_error(&stderr) {
+        Err(stderr)
       } else {
-        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+        Ok(())
       }
     },
     Err(e) => Err(e.to_string()),
@@ -727,14 +759,17 @@ fn can_access_journal(scope: UnitScope) -> Result<(), String> {
 
 /// Parse journalctl stderr to determine the specific error type
 pub fn parse_journalctl_error(stderr: &str) -> LogDiagnostic {
-  let stderr_lower = stderr.to_lowercase();
+  let trimmed = stderr.trim().to_string();
 
-  if stderr_lower.contains("permission denied") || stderr_lower.contains("access denied") {
-    LogDiagnostic::PermissionDenied { error: stderr.trim().to_string() }
-  } else if stderr_lower.contains("no such file") || stderr_lower.contains("failed to open") {
-    LogDiagnostic::JournalInaccessible { error: stderr.trim().to_string() }
+  if is_permission_error(stderr) {
+    LogDiagnostic::PermissionDenied { error: trimmed }
   } else {
-    LogDiagnostic::JournalctlError { stderr: stderr.trim().to_string() }
+    let lower = stderr.to_lowercase();
+    if lower.contains("no such file") || lower.contains("failed to open") {
+      LogDiagnostic::JournalInaccessible { error: trimmed }
+    } else {
+      LogDiagnostic::JournalctlError { stderr: trimmed }
+    }
   }
 }
 
@@ -785,5 +820,57 @@ mod tests {
   fn test_parse_journalctl_error_generic() {
     let diagnostic = parse_journalctl_error("Something unexpected happened");
     assert!(matches!(diagnostic, LogDiagnostic::JournalctlError { .. }));
+  }
+
+  #[test]
+  fn test_parse_journalctl_error_some_files_not_opened() {
+    // The exact warning that prompted this fix: journalctl exits 0 but emits
+    // this on stderr when only a subset of journal files are readable.
+    let diagnostic =
+      parse_journalctl_error("Warning: some journal files were not opened due to insufficient permissions.");
+    assert!(matches!(diagnostic, LogDiagnostic::PermissionDenied { .. }));
+  }
+
+  #[test]
+  fn test_parse_journalctl_error_no_files_opened() {
+    let diagnostic = parse_journalctl_error("No journal files were opened due to insufficient permissions.");
+    assert!(matches!(diagnostic, LogDiagnostic::PermissionDenied { .. }));
+  }
+
+  #[test]
+  fn test_parse_journalctl_error_rotated_warning() {
+    // The "journal has been rotated since unit was started" variant.
+    let diagnostic = parse_journalctl_error(
+      "Warning: journal has been rotated since unit was started and some journal files were not \
+       opened due to insufficient permissions, output may be incomplete.",
+    );
+    assert!(matches!(diagnostic, LogDiagnostic::PermissionDenied { .. }));
+  }
+
+  #[test]
+  fn test_parse_journalctl_error_hint_group() {
+    let diagnostic = parse_journalctl_error(
+      "Hint: You are currently not seeing messages from other users and the system. Users in the \
+       'systemd-journal' group can see all messages. Pass -q to turn off this notice.",
+    );
+    assert!(matches!(diagnostic, LogDiagnostic::PermissionDenied { .. }));
+  }
+
+  #[test]
+  fn test_is_permission_error() {
+    assert!(is_permission_error("Warning: some journal files were not opened due to insufficient permissions."));
+    assert!(is_permission_error("No journal files were opened due to insufficient permissions."));
+    assert!(is_permission_error("Permission denied"));
+    assert!(is_permission_error("Hint: ... Users in groups 'systemd-journal' can see all messages."));
+    assert!(!is_permission_error(""));
+    assert!(!is_permission_error("-- No entries --"));
+    assert!(!is_permission_error("some unrelated diagnostic"));
+  }
+
+  #[test]
+  fn test_permission_denied_message_mentions_group_and_sudo() {
+    let msg = LogDiagnostic::PermissionDenied { error: "any stderr".to_string() }.message();
+    assert!(msg.contains("systemd-journal"));
+    assert!(msg.contains("sudo"));
   }
 }

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -671,17 +671,21 @@ pub enum LogDiagnostic {
 }
 
 impl LogDiagnostic {
-  /// Returns a human-readable message for display
+  /// Returns a human-readable message for display.
+  ///
+  /// The message is always a single line: the log pane treats each entry as
+  /// one log line and does not honor embedded newlines, so multi-line text
+  /// would render as collapsed whitespace.
   pub fn message(&self) -> String {
     match self {
       Self::NeverRun { unit_name } => format!("No logs: {} has never been started", unit_name),
       Self::JournalInaccessible { error } => {
-        format!("Cannot access journal: {}\n\nCheck that systemd-journald is running", error)
+        format!("Cannot access journal: {} (check that systemd-journald is running)", error)
       },
       Self::PermissionDenied { error } => format!(
-        "Permission denied accessing journal:\n{}\n\nTry one of:\n  \
-         - Add your user to the 'systemd-journal' group: sudo usermod -aG systemd-journal $USER (then re-login)\n  \
-         - Run with sudo: sudo systemctl-tui",
+        "Permission denied accessing journal. Add your user to the 'systemd-journal' group \
+         (sudo usermod -aG systemd-journal $USER, then re-login) or run with sudo systemctl-tui. \
+         (journalctl: {})",
         error
       ),
       Self::NoLogsRecorded { unit_name } => {
@@ -757,18 +761,23 @@ fn can_access_journal(scope: UnitScope) -> Result<(), String> {
   }
 }
 
-/// Parse journalctl stderr to determine the specific error type
+/// Parse journalctl stderr to determine the specific error type.
+///
+/// The input may span multiple lines (e.g. the `Hint:` notice journalctl
+/// emits when the user is missing from the journal-reading groups), but the
+/// log pane that renders this message does not honor newlines. Collapse all
+/// whitespace runs to single spaces so the message renders cleanly.
 pub fn parse_journalctl_error(stderr: &str) -> LogDiagnostic {
-  let trimmed = stderr.trim().to_string();
+  let flattened = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
 
-  if is_permission_error(stderr) {
-    LogDiagnostic::PermissionDenied { error: trimmed }
+  if is_permission_error(&flattened) {
+    LogDiagnostic::PermissionDenied { error: flattened }
   } else {
-    let lower = stderr.to_lowercase();
+    let lower = flattened.to_lowercase();
     if lower.contains("no such file") || lower.contains("failed to open") {
-      LogDiagnostic::JournalInaccessible { error: trimmed }
+      LogDiagnostic::JournalInaccessible { error: flattened }
     } else {
-      LogDiagnostic::JournalctlError { stderr: trimmed }
+      LogDiagnostic::JournalctlError { stderr: flattened }
     }
   }
 }


### PR DESCRIPTION
Disclaimer: I've used the AI to help me diagnose and fix the issue I found, but I've reviewed all the code and I think it's ok.

## Summary

Users without `systemd-journal` group membership saw

> "No logs recorded for X (unit has run but produced no journal output)"

when the actual cause was that `journalctl` could only read a subset of journal files. This PR detects that case and shows an actionable `PermissionDenied` diagnostic instead.

## Why the previous logic missed it

`systemctl-tui` invokes `journalctl --quiet …`. Per `man journalctl`, `--quiet` *"suppresses any warning messages regarding inaccessible system journal files"*. So in the partial-permission case:

- `journalctl` exits **0** (some files are readable)
- stdout is **empty** (the unit's logs live in the inaccessible ones)
- stderr is **empty** (`--quiet` silenced the warning)

The success branch in `src/components/home.rs:537` then routed through `diagnose_missing_logs` → `can_access_journal` (also `--quiet`) → `Ok` → `NoLogsRecorded`, never reaching `parse_journalctl_error`.

## Changes (all in `src/systemd.rs`)

- **`can_access_journal`**: drop `--quiet`, inspect stderr even on exit 0. The probe doesn't need stdout content, so dropping `--quiet` costs nothing and lets the perm warning through.
- **`is_permission_error`** (new helper): single source of truth for the phrase list — `permission denied` / `access denied` / `insufficient permissions` / `not opened` / `can see all messages`.
- **`parse_journalctl_error`**: now delegates to `is_permission_error` instead of duplicating phrases. Also normalizes whitespace runs in the captured stderr so multi-line journalctl output (e.g. the 3-line `Hint:` notice) collapses to a single line.
- **`LogDiagnostic::message()`**: rewritten as flat single-line strings. The log pane treats each entry as one log line and does not honor embedded `\n`, so the previous multi-line templates rendered as a mashed-up paragraph. The `PermissionDenied` message now leads with the actionable remediation and ends with the journalctl context in parentheses.
- **Tests**: 7 new unit tests covering each phrase variant and the message format.

## Reproducing

```bash
DIR=/var/log/journal/$(cat /etc/machine-id)
# Deny your user on every persistent journal file
sudo find "$DIR" -maxdepth 1 -type f -exec setfacl -m u:$USER:--- {} +
# Re-allow on one old archive so the access probe still exits 0 (one file readable)
OLD=$(ls -t "$DIR"/system@*.journal~ | tail -1)
sudo setfacl -x u:$USER "$OLD"

./target/debug/systemctl-tui   # navigate to a recently-started system unit
                                # (e.g. avahi-daemon.service)

# cleanup
sudo find "$DIR" -maxdepth 1 -type f -exec setfacl -x u:$USER {} +
```

**Before:** `No logs recorded for avahi-daemon.service (unit has run but produced no journal output)`

**After:** a single-line, log-pane-friendly diagnostic:

> Permission denied accessing journal. Add your user to the 'systemd-journal' group (sudo usermod -aG systemd-journal $USER, then re-login) or run with sudo systemctl-tui. (journalctl: Hint: You are currently not seeing messages from other users and the system. Users in the 'systemd-journal' group can see all messages. Pass -q to turn off this notice.)

## Verification

- `cargo fmt`: clean
- `cargo clippy --all-targets`: 0 new warnings (3 pre-existing on master, unrelated)
- `cargo test --lib`: **13 passed** (7 new tests added)
- End-to-end TUI test under tmux confirmed user-facing behavior change for both system-scope and user-scope units, and confirmed the diagnostic now renders on a single visual line in the log pane.