### PR TITLE
Fix filtered list hiding top matches after clearing and retyping search

### DIFF
--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -345,6 +345,11 @@ impl Home {
     };
 
     self.filtered_units.items = matching;
+    // Reset the visible-window offset whenever the items list is rebuilt.
+    // Without this, a stale offset from a larger list can leave items above the
+    // viewport hidden when the list shrinks (e.g. typing a query, clearing it,
+    // and retyping it can leave the first matches scrolled out of view).
+    *self.filtered_units.state.offset_mut() = 0;
 
     // try to select the same item we had selected before
     if let Some(previously_selected) = previously_selected {


### PR DESCRIPTION
## Summary

Fixes a bug where filtering, navigating, clearing the query, then retyping it could hide the top matches from the service list — e.g. with `keeper@`, `keeper@1`, `keeper@2`, `keeper@3` services, selecting `keeper@3`, clearing the search, and retyping `keeper` would only show `keeper@3` (and `pk-debconf-helper`), with the other three keeper entries scrolled out of view.

## Reproduction

1. Open the TUI with no flags.
2. `Ctrl+f` and type `keeper`.
3. Arrow-down to `keeper@3`.
4. `Ctrl+f`, backspace the query empty, retype `keeper`.

Expected: all matches shown. Actual: `keeper@`, `keeper@1`, `keeper@2` are hidden.

## Root cause

In `Home::refresh_filtered_units` (`src/components/home.rs`), when the search is cleared the items list grows to all ~294 units and the selection is restored to the previously-selected unit's new index (e.g. `keeper@3` at ~78). Ratatui's `ListState` auto-scrolls `offset` to keep that index visible. When the query is retyped and the list shrinks back to 5 entries, the selection is restored to its new (small) index but the previously-pushed-down `offset` is **not** reset — so with `offset=3` and `items.len=5`, ratatui only renders `items[3..5]`, hiding the entries above.

## Fix

Reset `state.offset` to `0` whenever `filtered_units.items` is rebuilt. Ratatui's auto-scroll then re-derives a sensible viewport that fits the new list size; the existing logic that restores the previously-selected index continues to work unchanged.

```rust
self.filtered_units.items = matching;
*self.filtered_units.state.offset_mut() = 0;
```

## Verification

- Manually reproduced the bug on master, verified it is gone after the fix (captured rendered TUI output with pyte to confirm).
- `cargo fmt` clean.
- `cargo clippy` has 3 pre-existing warnings on master; none introduced by this change.