### PR TITLE
Support remote hosts via `--host` flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,40 @@ jobs:
 
     - name: Run tests
       run: cargo test
+
+  # End-to-end test of --host support: drives the real binary in tmux against
+  # sshd on the runner itself (GitHub runners run real systemd)
+  remote_integration:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache dependencies
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install tmux, sshd, and uv
+      run: |
+        sudo apt-get update && sudo apt-get install -y tmux openssh-server
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    - name: Set up passwordless ssh to localhost
+      run: |
+        sudo systemctl start ssh
+        ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519
+        cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+        chmod 600 ~/.ssh/authorized_keys
+        ssh-keyscan -H localhost >> ~/.ssh/known_hosts
+        # let the runner user read the system journal so logs render
+        # (takes effect for ssh sessions immediately since they are fresh logins)
+        sudo usermod -aG systemd-journal "$USER"
+        ssh -o BatchMode=yes localhost true
+
+    - name: Build
+      run: cargo build
+
+    - name: Run remote integration tests
+      run: ./scripts/remote-integration-test.py --host localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
     - name: Run tests
       run: cargo test
 
-  # End-to-end test of --host support: drives the real binary in tmux against
-  # sshd on the runner itself (GitHub runners run real systemd)
-  remote_integration:
+  # End-to-end tests: drives the real binary in tmux, both against local systemd
+  # and in --host mode against sshd on the runner itself (runners run real systemd)
+  integration:
     runs-on: ubuntu-latest
 
     steps:
@@ -65,5 +65,8 @@ jobs:
     - name: Build
       run: cargo build
 
-    - name: Run remote integration tests
-      run: ./scripts/remote-integration-test.py --host localhost
+    - name: Run integration tests (local)
+      run: ./scripts/integration-test.py
+
+    - name: Run integration tests (remote via ssh localhost)
+      run: ./scripts/integration-test.py --host localhost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,14 @@ tmux resize-pane -t sctui-test -x 80 -y 24
 tmux kill-session -t sctui-test 2>/dev/null
 ```
 
-Note: `tmux capture-pane -p` returns empty content for alternate-screen TUI apps. To verify rendering, check stderr (where the TUI escape codes go) or just confirm the process hasn't crashed. The primary signals for a passing test are:
+Use `tmux capture-pane -t sctui-test -p` to read the rendered screen and assert on its contents (it captures alternate-screen apps fine). The primary signals for a passing test are:
 
 1. Process is still alive after each interaction
-2. No panics or errors in stderr
-3. Process exits cleanly on `q`
+2. `capture-pane` shows the expected content (services list, dialogs, logs)
+3. No panics or errors in stderr
+4. Process exits cleanly on `q` (note: press `Escape` first if in search mode, where `q` is just text input)
+
+For remote host (`--host`) changes, run the end-to-end suite in `scripts/remote-integration-test.py` against a host you can ssh to without a password (it includes a keystroke-drop regression test that scripted manual testing tends to miss).
 
 ### Test checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Use `tmux capture-pane -t sctui-test -p` to read the rendered screen and assert 
 3. No panics or errors in stderr
 4. Process exits cleanly on `q` (note: press `Escape` first if in search mode, where `q` is just text input)
 
-For remote host (`--host`) changes, run the end-to-end suite in `scripts/remote-integration-test.py` against a host you can ssh to without a password (it includes a keystroke-drop regression test that scripted manual testing tends to miss).
+`scripts/integration-test.py` automates this checklist end-to-end (local by default, or `--host user@hostname` for remote mode; it includes a keystroke-drop regression test that manual testing tends to miss). Prefer running it over hand-rolling tmux commands.
 
 ### Test checklist
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ nix-shell -p systemctl-tui
 sudo ln -s ~/.cargo/bin/systemctl-tui /usr/bin/systemctl-tui
 ```
 
+## Remote hosts
+
+`systemctl-tui --host user@hostname` manages a remote machine over SSH, no remote install needed. Service operations go over a [systemd-stdio-bridge](https://www.freedesktop.org/software/systemd/man/latest/systemd-stdio-bridge.html) D-Bus connection (like `systemctl --host`) and logs come from running `journalctl` on the remote host, all multiplexed over a single SSH connection.
+
+The remote host needs `systemd-stdio-bridge` (part of systemd) and `journalctl`. Viewing user-scope services requires a running user manager on the remote host (an active session, or lingering enabled via `loginctl enable-linger`). Editing unit files remotely is not supported yet.
+
 ## Help
 ![image](https://github.com/rgwood/systemctl-tui/assets/26268125/b1b49850-61c4-4667-9110-20a34f917055)
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sudo ln -s ~/.cargo/bin/systemctl-tui /usr/bin/systemctl-tui
 
 `systemctl-tui --host user@hostname` manages a remote machine over SSH, no remote install needed. Service operations go over a [systemd-stdio-bridge](https://www.freedesktop.org/software/systemd/man/latest/systemd-stdio-bridge.html) D-Bus connection (like `systemctl --host`) and logs come from running `journalctl` on the remote host, all multiplexed over a single SSH connection.
 
-The remote host needs `systemd-stdio-bridge` (part of systemd) and `journalctl`. Viewing user-scope services requires a running user manager on the remote host (an active session, or lingering enabled via `loginctl enable-linger`). Editing unit files remotely is not supported yet.
+The remote host needs `systemd-stdio-bridge` (part of the core systemd package on all major distros; verified working on systemd 249 and 255, and the flags we use exist back to at least systemd 239) and `journalctl`. Viewing user-scope services requires a running user manager on the remote host (an active session, or lingering enabled via `loginctl enable-linger`). Editing unit files remotely is not supported yet.
 
 ## Help
 ![image](https://github.com/rgwood/systemctl-tui/assets/26268125/b1b49850-61c4-4667-9110-20a34f917055)

--- a/scripts/integration-test.py
+++ b/scripts/integration-test.py
@@ -3,17 +3,18 @@
 # requires-python = ">=3.12"
 # dependencies = []
 # ///
-"""Integration tests for systemctl-tui's remote host support (--host flag).
+"""Integration tests for systemctl-tui.
 
-Drives the real binary in a tmux session against a real SSH host and asserts on
-rendered output. Works locally against any host you can ssh to without a
-password (default: localhost) and in CI.
+Drives the real binary in a tmux session and asserts on rendered output.
+By default it tests against local systemd; pass --host to run the same tests
+against a remote machine over SSH.
 
 Usage:
-    ./scripts/remote-integration-test.py [--host user@hostname] [--binary path]
+    ./scripts/integration-test.py                        # local
+    ./scripts/integration-test.py --host user@hostname   # remote
 
-Requires: tmux, passwordless ssh to the target, and a debug build
-(`cargo build`) unless --binary is given.
+Requires: tmux and a debug build (`cargo build`). Remote mode needs
+passwordless ssh to the target.
 """
 
 import argparse
@@ -46,9 +47,10 @@ def send_keys(*keys: str, delay: float = 0.0) -> None:
             time.sleep(delay)
 
 
-def start_app(binary: str, host: str, extra_args: list[str] | None = None) -> None:
+def start_app(binary: str, host: str | None, extra_args: list[str] | None = None) -> None:
     tmux("kill-session", "-t", SESSION)
-    args = [binary, "--host", host, *(extra_args or [])]
+    host_args = ["--host", host] if host else []
+    args = [binary, *host_args, *(extra_args or [])]
     cmd = " ".join(f"'{a}'" for a in args)
     tmux("new-session", "-d", "-s", SESSION, "-x", "120", "-y", "40", cmd)
 
@@ -82,11 +84,11 @@ def wait_for(predicate, timeout: float = 15.0, interval: float = 0.5) -> bool:
     return False
 
 
-def test_startup_and_browse(binary: str, host: str) -> None:
+def test_startup_and_browse(binary: str, host: str | None) -> None:
     print("startup and browsing:")
     start_app(binary, host)
     check("app launches and renders", wait_for(lambda: "Services" in capture()))
-    check("services listed from remote", wait_for(lambda: ".service" in capture() or "Details" in capture()))
+    check("services listed", wait_for(lambda: ".service" in capture() or "Details" in capture()))
 
     # navigate: initial mode is Search, Down selects the first unit
     send_keys("Down")
@@ -107,12 +109,20 @@ def test_startup_and_browse(binary: str, host: str) -> None:
     send_keys("Escape")
     time.sleep(1)
 
+    # resize, including a very small terminal
+    tmux("resize-window", "-t", SESSION, "-x", "40", "-y", "15")
+    time.sleep(1)
+    alive_when_small = app_alive()
+    tmux("resize-window", "-t", SESSION, "-x", "120", "-y", "40")
+    time.sleep(1)
+    check("survives resizing", alive_when_small and app_alive())
+
     check("app still alive after interactions", app_alive())
 
 
-def test_remote_logs(binary: str, host: str) -> None:
+def test_logs(binary: str, host: str | None) -> None:
     """Logs should either render, or show an actionable diagnostic - never a crash."""
-    print("remote logs:")
+    print("logs:")
     # dbus.service exists and has run on any systemd machine
     start_app(binary, host, ["--limit-units", "dbus.service"])
     wait_for(lambda: "Details" in capture())
@@ -128,15 +138,15 @@ def test_remote_logs(binary: str, host: str) -> None:
     check("app still alive", app_alive())
 
 
-def test_no_dropped_keystrokes(binary: str, host: str) -> None:
+def test_no_dropped_keystrokes(binary: str, host: str | None) -> None:
     """Regression test: ssh children used to inherit (and eat) the TUI's stdin.
 
-    Typing changes the selection, which kicks off remote log fetches; keys
-    pressed while a fetch is in flight were forwarded to ssh instead of the
-    app. 30ms is fast human typing; before the fix this dropped keys in ~80%
-    of runs.
+    Typing changes the selection, which kicks off log fetches; in remote mode,
+    keys pressed while a fetch was in flight were forwarded to ssh instead of
+    the app. 30ms is fast human typing; before the fix this dropped keys in
+    ~80% of remote runs. Cheap enough to run locally too.
     """
-    print("keystroke drops (stdin regression):")
+    print("keystroke drops:")
     text = "systemdnetworkd"
     for ms in (30, 10):
         start_app(binary, host)
@@ -151,7 +161,7 @@ def test_no_dropped_keystrokes(binary: str, host: str) -> None:
         )
 
 
-def test_clean_exit(binary: str, host: str) -> None:
+def test_clean_exit(binary: str, host: str | None) -> None:
     print("clean exit:")
     start_app(binary, host)
     wait_for(lambda: "Services" in capture())
@@ -163,20 +173,21 @@ def test_clean_exit(binary: str, host: str) -> None:
     check("q exits the app", wait_for(lambda: not app_alive(), timeout=10))
 
 
-def check_prerequisites(binary: str, host: str) -> str | None:
+def check_prerequisites(binary: str, host: str | None) -> str | None:
     if run(["which", "tmux"]).returncode != 0:
         return "tmux is not installed"
     if run(["test", "-x", binary]).returncode != 0:
         return f"binary not found at {binary} (run `cargo build` first)"
-    ssh_check = run(["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", host, "true"])
-    if ssh_check.returncode != 0:
-        return f"cannot ssh to {host} without a password: {ssh_check.stderr.strip()}"
+    if host:
+        ssh_check = run(["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", host, "true"])
+        if ssh_check.returncode != 0:
+            return f"cannot ssh to {host} without a password: {ssh_check.stderr.strip()}"
     return None
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--host", default="localhost", help="ssh target (default: localhost)")
+    parser.add_argument("--host", default=None, help="ssh target for remote mode (default: test locally)")
     parser.add_argument("--binary", default="./target/debug/systemctl-tui")
     args = parser.parse_args()
 
@@ -185,9 +196,10 @@ def main() -> int:
         print(f"SKIP: {problem}")
         return 2
 
+    print(f"testing against: {args.host or 'local systemd'}\n")
     try:
         test_startup_and_browse(args.binary, args.host)
-        test_remote_logs(args.binary, args.host)
+        test_logs(args.binary, args.host)
         test_no_dropped_keystrokes(args.binary, args.host)
         test_clean_exit(args.binary, args.host)
     finally:

--- a/scripts/remote-integration-test.py
+++ b/scripts/remote-integration-test.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Integration tests for systemctl-tui's remote host support (--host flag).
+
+Drives the real binary in a tmux session against a real SSH host and asserts on
+rendered output. Works locally against any host you can ssh to without a
+password (default: localhost) and in CI.
+
+Usage:
+    ./scripts/remote-integration-test.py [--host user@hostname] [--binary path]
+
+Requires: tmux, passwordless ssh to the target, and a debug build
+(`cargo build`) unless --binary is given.
+"""
+
+import argparse
+import subprocess
+import sys
+import time
+
+SESSION = "sctui-integration-test"
+
+passed: list[str] = []
+failed: list[str] = []
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=30, **kwargs)
+
+
+def tmux(*args: str) -> subprocess.CompletedProcess:
+    return run(["tmux", *args])
+
+
+def capture() -> str:
+    return tmux("capture-pane", "-t", SESSION, "-p").stdout
+
+
+def send_keys(*keys: str, delay: float = 0.0) -> None:
+    for key in keys:
+        tmux("send-keys", "-t", SESSION, key)
+        if delay:
+            time.sleep(delay)
+
+
+def start_app(binary: str, host: str, extra_args: list[str] | None = None) -> None:
+    tmux("kill-session", "-t", SESSION)
+    args = [binary, "--host", host, *(extra_args or [])]
+    cmd = " ".join(f"'{a}'" for a in args)
+    tmux("new-session", "-d", "-s", SESSION, "-x", "120", "-y", "40", cmd)
+
+
+def stop_app() -> None:
+    tmux("kill-session", "-t", SESSION)
+
+
+def app_alive() -> bool:
+    result = tmux("list-panes", "-t", SESSION, "-F", "#{pane_dead}")
+    return result.returncode == 0 and result.stdout.strip() == "0"
+
+
+def check(name: str, condition: bool, context: str = "") -> None:
+    if condition:
+        passed.append(name)
+        print(f"  PASS  {name}")
+    else:
+        failed.append(name)
+        print(f"  FAIL  {name}")
+        if context:
+            print(f"        {context}")
+
+
+def wait_for(predicate, timeout: float = 15.0, interval: float = 0.5) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_startup_and_browse(binary: str, host: str) -> None:
+    print("startup and browsing:")
+    start_app(binary, host)
+    check("app launches and renders", wait_for(lambda: "Services" in capture()))
+    check("services listed from remote", wait_for(lambda: ".service" in capture() or "Details" in capture()))
+
+    # navigate: initial mode is Search, Down selects the first unit
+    send_keys("Down")
+    time.sleep(1)
+    check("selection shows details", "Description:" in capture(), capture())
+
+    # help screen
+    send_keys("?")
+    time.sleep(1)
+    check("help screen opens", "Shortcuts" in capture())
+    send_keys("Escape")
+    time.sleep(1)
+
+    # action menu
+    send_keys("Enter")
+    time.sleep(1)
+    check("action menu opens", "Actions for" in capture(), capture())
+    send_keys("Escape")
+    time.sleep(1)
+
+    check("app still alive after interactions", app_alive())
+
+
+def test_remote_logs(binary: str, host: str) -> None:
+    """Logs should either render, or show an actionable diagnostic - never a crash."""
+    print("remote logs:")
+    # dbus.service exists and has run on any systemd machine
+    start_app(binary, host, ["--limit-units", "dbus.service"])
+    wait_for(lambda: "Details" in capture())
+    send_keys("Down")
+
+    def logs_or_diagnostic() -> bool:
+        screen = capture()
+        rendered_logs = "systemd[1]" in screen or "dbus" in screen.lower()
+        diagnostic = "No access to system logs" in screen or "No logs" in screen
+        return rendered_logs or diagnostic
+
+    check("logs pane shows logs or diagnostic", wait_for(logs_or_diagnostic), capture())
+    check("app still alive", app_alive())
+
+
+def test_no_dropped_keystrokes(binary: str, host: str) -> None:
+    """Regression test: ssh children used to inherit (and eat) the TUI's stdin.
+
+    Typing changes the selection, which kicks off remote log fetches; keys
+    pressed while a fetch is in flight were forwarded to ssh instead of the
+    app. 30ms is fast human typing; before the fix this dropped keys in ~80%
+    of runs.
+    """
+    print("keystroke drops (stdin regression):")
+    text = "systemdnetworkd"
+    for ms in (30, 10):
+        start_app(binary, host)
+        wait_for(lambda: "Services" in capture())
+        send_keys(*text, delay=ms / 1000)
+        time.sleep(2)
+        search_line = capture().splitlines()[1] if len(capture().splitlines()) > 1 else ""
+        check(
+            f"no dropped keys at {ms}ms intervals",
+            text in search_line.replace("│", "").strip(),
+            f"search box: {search_line!r}",
+        )
+
+
+def test_clean_exit(binary: str, host: str) -> None:
+    print("clean exit:")
+    start_app(binary, host)
+    wait_for(lambda: "Services" in capture())
+    # initial mode is Search where q would be typed into the box; Escape first
+    send_keys("Escape")
+    time.sleep(0.5)
+    send_keys("q")
+    # the pane dies when the app exits, so the session disappears
+    check("q exits the app", wait_for(lambda: not app_alive(), timeout=10))
+
+
+def check_prerequisites(binary: str, host: str) -> str | None:
+    if run(["which", "tmux"]).returncode != 0:
+        return "tmux is not installed"
+    if run(["test", "-x", binary]).returncode != 0:
+        return f"binary not found at {binary} (run `cargo build` first)"
+    ssh_check = run(["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=5", host, "true"])
+    if ssh_check.returncode != 0:
+        return f"cannot ssh to {host} without a password: {ssh_check.stderr.strip()}"
+    return None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="localhost", help="ssh target (default: localhost)")
+    parser.add_argument("--binary", default="./target/debug/systemctl-tui")
+    args = parser.parse_args()
+
+    problem = check_prerequisites(args.binary, args.host)
+    if problem:
+        print(f"SKIP: {problem}")
+        return 2
+
+    try:
+        test_startup_and_browse(args.binary, args.host)
+        test_remote_logs(args.binary, args.host)
+        test_no_dropped_keystrokes(args.binary, args.host)
+        test_clean_exit(args.binary, args.host)
+    finally:
+        stop_app()
+
+    print(f"\n{len(passed)} passed, {len(failed)} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/app.rs
+++ b/src/app.rs
@@ -94,6 +94,11 @@ impl App {
           Action::Resize(_, _) => terminal.render().await,
           // This would normally be in home.rs, but it needs to do some terminal and event handling stuff that's easier here
           Action::EditUnitFile { unit, path } => {
+            // The unit file lives on the remote host; we can't open it in a local editor
+            if crate::ssh::remote_host().is_some() {
+              action_tx.send(Action::EnterError("Editing unit files on remote hosts is not supported (yet)".into()))?;
+              continue;
+            }
             event.stop();
             let mut tui = terminal.tui.lock().await;
             tui.exit()?;

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -337,7 +337,7 @@ impl Home {
         .collect();
 
       // Sort by score descending (best matches first)
-      scored.sort_by(|a, b| b.0.cmp(&a.0));
+      scored.sort_by_key(|(score, _)| std::cmp::Reverse(*score));
       scored.into_iter().map(|(_, m)| m).collect()
     };
 
@@ -754,7 +754,8 @@ impl Component for Home {
       },
       Action::EnterMode(mode) => {
         if mode == Mode::ActionMenu {
-          if let Some(selected) = self.filtered_units.selected() {
+          {
+            let selected = self.filtered_units.selected()?;
             let mut menu_items = vec![
               MenuItem::new("Start", Action::StartService(selected.unit.id()), Some(KeyCode::Char('s'))),
               MenuItem::new("Stop", Action::StopService(selected.unit.id()), Some(KeyCode::Char('t'))),
@@ -781,11 +782,10 @@ impl Component for Home {
 
             self.menu_items = StatefulList::with_items(menu_items);
             self.menu_items.state.select(Some(0));
-          } else {
-            return None;
           }
         } else if mode == Mode::SignalMenu {
-          if let Some(selected) = self.filtered_units.selected() {
+          {
+            let selected = self.filtered_units.selected()?;
             let signals = vec![
               ("SIGTERM", KeyCode::Char('t')),
               ("SIGHUP", KeyCode::Char('h')),
@@ -805,8 +805,6 @@ impl Component for Home {
 
             self.menu_items = StatefulList::with_items(menu_items);
             self.menu_items.state.select(Some(0));
-          } else {
-            return None;
           }
         }
 

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -19,10 +19,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use tui_input::{backend::crossterm::EventHandler, Input};
 
-use std::{
-  process::{Command, Stdio},
-  time::Duration,
-};
+use std::{process::Stdio, time::Duration};
 
 use super::{logger::Logger, Component, Frame};
 use crate::{
@@ -531,7 +528,7 @@ impl Component for Home {
           args.push("--user");
         }
 
-        match Command::new("journalctl").args(&args).output() {
+        match crate::ssh::host_command("journalctl", &args).output() {
           Ok(output) => {
             if output.status.success() {
               info!("Got logs for {} in {:?}", unit.name, start.elapsed());
@@ -568,19 +565,14 @@ impl Component for Home {
         // This does mean that we'll miss any logs that are written between the two commands, low enough risk for now
         let tx = tx.clone();
         last_follow_handle = Some(tokio::spawn(async move {
-          let mut command = tokio::process::Command::new("journalctl");
-          command.arg("-u");
-          command.arg(unit.name.clone());
-          command.arg("--output=short-iso");
-          command.arg("--follow");
-          command.arg("--lines=0");
-          command.arg("--quiet");
+          let mut args = vec!["-u", &unit.name, "--output=short-iso", "--follow", "--lines=0", "--quiet"];
+          if unit.scope == UnitScope::User {
+            args.push("--user");
+          }
+          let mut command = crate::ssh::host_tokio_command("journalctl", &args);
           command.stdout(Stdio::piped());
           command.stderr(Stdio::piped());
-
-          if unit.scope == UnitScope::User {
-            command.arg("--user");
-          }
+          command.kill_on_drop(true);
 
           let mut child = command.spawn().expect("failed to execute process");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,5 @@ pub mod terminal;
 pub mod utils;
 
 pub mod systemd;
+
+pub mod ssh;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand, ValueEnum};
 use systemctl_tui::{
   app::App,
-  systemd,
+  ssh, systemd,
   utils::{get_data_dir, initialize_logging, initialize_panic_handler, version},
 };
 
@@ -26,6 +26,9 @@ struct Args {
   /// Limit view to only these unit files
   #[clap(short, long, default_value="*.service", num_args=1..)]
   limit_units: Vec<String>,
+  /// Manage a remote host over SSH (e.g. user@hostname). Requires systemd-stdio-bridge on the remote host.
+  #[clap(long)]
+  host: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -81,8 +84,20 @@ async fn main() -> Result<()> {
     },
   };
 
+  // Connect before entering the TUI so SSH auth prompts (password, 2FA) work
+  if let Some(host) = args.host {
+    println!("Connecting to {host}...");
+    if let Err(e) = ssh::init(host) {
+      // ssh has already printed its own error to stderr
+      eprintln!("{e}");
+      std::process::exit(1);
+    }
+  }
+
   let mut app = App::new(scope, args.limit_units)?;
-  app.run().await?;
+  let result = app.run().await;
+  ssh::teardown();
+  result?;
 
   Ok(())
 }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -73,13 +73,14 @@ impl SshHost {
         args.push("--system".into());
       },
       UnitScope::User => {
-        // Non-interactive SSH sessions have no XDG_RUNTIME_DIR, so the bridge can't find the
-        // user bus without help. Requires a running user manager (active session or lingering).
+        // `systemd-stdio-bridge --user` is unreliable in non-interactive SSH sessions (it can
+        // silently serve the system bus or fail outright), so point it at the user bus socket
+        // explicitly. Requires a running user manager (active session or lingering).
         // The remote shell word-splits ssh's command string, so the -c payload must be quoted;
         // $(id -u) is expanded by the remote sh, not locally.
         args.push("sh".into());
         args.push("-c".into());
-        args.push("'XDG_RUNTIME_DIR=/run/user/$(id -u) exec systemd-stdio-bridge --user'".into());
+        args.push("'exec systemd-stdio-bridge -p unix:path=/run/user/$(id -u)/bus'".into());
       },
     }
     args

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -168,4 +168,87 @@ mod tests {
     assert_eq!(shell_quote("it's"), r"'it'\''s'");
     assert_eq!(shell_quote(""), "''");
   }
+
+  fn test_host() -> SshHost {
+    SshHost { host: "user@example".into(), control_path: PathBuf::from("/tmp/ctl-%C") }
+  }
+
+  fn args_of(cmd: &Command) -> Vec<String> {
+    cmd.get_args().map(|a| a.to_string_lossy().into_owned()).collect()
+  }
+
+  #[test]
+  fn test_remote_command_args() {
+    let host = test_host();
+    let cmd = host.command("journalctl", &["--lines=500", "-u", "foo bar.service"]);
+    assert_eq!(cmd.get_program(), "ssh");
+    assert_eq!(
+      args_of(&cmd),
+      vec![
+        "-xT",
+        "-o",
+        "ControlPath=/tmp/ctl-%C",
+        "-o",
+        "BatchMode=yes",
+        "--",
+        "user@example",
+        "journalctl",
+        "--lines=500",
+        "-u",
+        // quoted so the remote shell doesn't word-split it
+        "'foo bar.service'",
+      ]
+    );
+    // NOTE: stdin must be null for remote commands (ssh steals terminal input otherwise),
+    // but std::process::Command has no getter for stdio config. The remote integration
+    // test's typing check covers that regression.
+  }
+
+  #[test]
+  fn test_tokio_command_matches_std_command() {
+    let host = test_host();
+    let std_cmd = host.command("systemctl", &["show", "-P", "FragmentPath", "foo.service"]);
+    let tokio_cmd = host.tokio_command("systemctl", &["show", "-P", "FragmentPath", "foo.service"]);
+    assert_eq!(args_of(tokio_cmd.as_std()), args_of(&std_cmd));
+  }
+
+  #[test]
+  fn test_bridge_args_global() {
+    let host = test_host();
+    let args: Vec<String> =
+      host.bridge_ssh_args(UnitScope::Global).iter().map(|a| a.to_string_lossy().into_owned()).collect();
+    assert_eq!(
+      args,
+      vec![
+        "-xT",
+        "-o",
+        "ControlPath=/tmp/ctl-%C",
+        "-o",
+        "BatchMode=yes",
+        "--",
+        "user@example",
+        "systemd-stdio-bridge",
+        "--system",
+      ]
+    );
+  }
+
+  #[test]
+  fn test_bridge_args_user() {
+    let host = test_host();
+    let args: Vec<String> =
+      host.bridge_ssh_args(UnitScope::User).iter().map(|a| a.to_string_lossy().into_owned()).collect();
+    // the -c payload must stay single-quoted: the remote shell word-splits ssh's
+    // command string, and $(id -u) must be expanded remotely, not locally
+    assert_eq!(args[args.len() - 3..], ["sh", "-c", "'exec systemd-stdio-bridge -p unix:path=/run/user/$(id -u)/bus'"]);
+    assert_eq!(args[args.len() - 4], "user@example");
+  }
+
+  #[test]
+  fn test_local_command_passthrough() {
+    // no remote host initialized in tests, so host_command should run the program directly
+    let cmd = host_command("journalctl", &["--lines=1"]);
+    assert_eq!(cmd.get_program(), "journalctl");
+    assert_eq!(args_of(&cmd), vec!["--lines=1"]);
+  }
 }

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -31,13 +31,14 @@ pub fn remote_host() -> Option<&'static SshHost> {
 /// Must be called before entering the alternate screen so password/2FA prompts work.
 pub fn init(host: String) -> Result<()> {
   let runtime_dir = std::env::var("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap_or_else(|_| std::env::temp_dir());
-  // %C expands to a hash of local host, remote host, port, and user
-  let control_path = runtime_dir.join("systemctl-tui-ssh-%C");
+  // %C expands to a hash of local host, remote host, port, and user. Include our PID so that
+  // concurrent instances don't share a master (teardown would kill it out from under the other)
+  let control_path = runtime_dir.join(format!("systemctl-tui-ssh-{}-%C", std::process::id()));
 
   let status = Command::new("ssh")
     .args(["-o", "ControlMaster=auto", "-o"])
     .arg(format!("ControlPath={}", control_path.display()))
-    .args(["-o", "ControlPersist=60", "-N", "-f", "--", &host])
+    .args(["-o", "ControlPersist=60", "-o", "ConnectTimeout=10", "-N", "-f", "--", &host])
     .status()
     .context("Failed to run ssh. Is OpenSSH installed?")?;
 
@@ -45,14 +46,24 @@ pub fn init(host: String) -> Result<()> {
     bail!("Failed to connect to {host} over SSH");
   }
 
-  REMOTE_HOST.set(SshHost { host, control_path }).expect("ssh::init called twice");
+  let ssh_host = SshHost { host, control_path };
+
+  // Fail now with a clear message rather than later with an opaque D-Bus error
+  let bridge_check = ssh_host.command("command", &["-v", "systemd-stdio-bridge"]).output();
+  if !bridge_check.map(|o| o.status.success()).unwrap_or(false) {
+    let host = &ssh_host.host;
+    ssh_host.close_master();
+    bail!("systemd-stdio-bridge not found on {host}. It ships with systemd; is {host} running a systemd distro?");
+  }
+
+  REMOTE_HOST.set(ssh_host).expect("ssh::init called twice");
   Ok(())
 }
 
 /// Close the master connection. Safe to skip (ControlPersist expires it), but tidy.
 pub fn teardown() {
   if let Some(ssh_host) = remote_host() {
-    let _ = Command::new("ssh").args(ssh_host.mux_options()).args(["-O", "exit", "--", &ssh_host.host]).output();
+    ssh_host.close_master();
   }
 }
 
@@ -86,10 +97,14 @@ impl SshHost {
     args
   }
 
+  fn close_master(&self) {
+    let _ = Command::new("ssh").args(self.mux_options()).args(["-O", "exit", "--", &self.host]).output();
+  }
+
   /// Build a `std::process::Command` that runs `program args...` on the remote host.
   pub fn command(&self, program: &str, args: &[&str]) -> Command {
     let mut cmd = Command::new("ssh");
-    self.add_remote_invocation(&mut cmd, program, args);
+    cmd.args(self.remote_invocation_args(program, args));
     // ssh forwards its stdin to the remote command; if it inherits the TUI's stdin it
     // steals keystrokes from the terminal
     cmd.stdin(std::process::Stdio::null());
@@ -99,24 +114,21 @@ impl SshHost {
   /// Like [`SshHost::command`] but for tokio.
   pub fn tokio_command(&self, program: &str, args: &[&str]) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new("ssh");
-    let mut std_cmd = Command::new("ssh");
-    self.add_remote_invocation(&mut std_cmd, program, args);
-    cmd.args(std_cmd.get_args());
+    cmd.args(self.remote_invocation_args(program, args));
     // same stdin-stealing hazard as in `command` above
     cmd.stdin(std::process::Stdio::null());
     cmd
   }
 
-  fn add_remote_invocation(&self, cmd: &mut Command, program: &str, args: &[&str]) {
-    cmd.arg("-xT");
-    cmd.args(self.mux_options());
-    cmd.arg("--");
-    cmd.arg(&self.host);
+  fn remote_invocation_args(&self, program: &str, args: &[&str]) -> Vec<String> {
+    let mut ssh_args = vec!["-xT".to_string()];
+    ssh_args.extend(self.mux_options());
+    ssh_args.push("--".into());
+    ssh_args.push(self.host.clone());
     // ssh concatenates arguments and hands them to the remote shell, so quote each one
-    cmd.arg(shell_quote(program));
-    for arg in args {
-      cmd.arg(shell_quote(arg));
-    }
+    ssh_args.push(shell_quote(program));
+    ssh_args.extend(args.iter().map(|arg| shell_quote(arg)));
+    ssh_args
   }
 }
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,0 +1,165 @@
+//! Support for managing systemd on remote hosts over SSH (the `--host` flag).
+//!
+//! We establish a multiplexed SSH master connection at startup (before entering the TUI, so
+//! interactive auth prompts work), then every subsequent SSH invocation — D-Bus bridges and
+//! journalctl/systemctl calls — reuses it via ControlPath. That makes each call a cheap channel
+//! open instead of a full handshake.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::OnceLock;
+
+use anyhow::{bail, Context, Result};
+
+use crate::systemd::UnitScope;
+
+static REMOTE_HOST: OnceLock<SshHost> = OnceLock::new();
+
+#[derive(Debug)]
+pub struct SshHost {
+  pub host: String,
+  control_path: PathBuf,
+}
+
+/// The remote host we're connected to, if any. Set once at startup via [`init`].
+pub fn remote_host() -> Option<&'static SshHost> {
+  REMOTE_HOST.get()
+}
+
+/// Establish a multiplexed SSH master connection to `host` (e.g. `user@hostname`).
+/// Must be called before entering the alternate screen so password/2FA prompts work.
+pub fn init(host: String) -> Result<()> {
+  let runtime_dir = std::env::var("XDG_RUNTIME_DIR").map(PathBuf::from).unwrap_or_else(|_| std::env::temp_dir());
+  // %C expands to a hash of local host, remote host, port, and user
+  let control_path = runtime_dir.join("systemctl-tui-ssh-%C");
+
+  let status = Command::new("ssh")
+    .args(["-o", "ControlMaster=auto", "-o"])
+    .arg(format!("ControlPath={}", control_path.display()))
+    .args(["-o", "ControlPersist=60", "-N", "-f", "--", &host])
+    .status()
+    .context("Failed to run ssh. Is OpenSSH installed?")?;
+
+  if !status.success() {
+    bail!("Failed to connect to {host} over SSH");
+  }
+
+  REMOTE_HOST.set(SshHost { host, control_path }).expect("ssh::init called twice");
+  Ok(())
+}
+
+/// Close the master connection. Safe to skip (ControlPersist expires it), but tidy.
+pub fn teardown() {
+  if let Some(ssh_host) = remote_host() {
+    let _ = Command::new("ssh").args(ssh_host.mux_options()).args(["-O", "exit", "--", &ssh_host.host]).output();
+  }
+}
+
+impl SshHost {
+  fn mux_options(&self) -> [String; 4] {
+    ["-o".into(), format!("ControlPath={}", self.control_path.display()), "-o".into(), "BatchMode=yes".into()]
+  }
+
+  /// Arguments for the `unixexec:` D-Bus transport: run systemd-stdio-bridge on the remote host.
+  pub fn bridge_ssh_args(&self, scope: UnitScope) -> Vec<OsString> {
+    let mut args: Vec<OsString> = vec!["-xT".into()];
+    args.extend(self.mux_options().map(OsString::from));
+    args.push("--".into());
+    args.push(OsString::from(&self.host));
+    match scope {
+      UnitScope::Global => {
+        args.push("systemd-stdio-bridge".into());
+        args.push("--system".into());
+      },
+      UnitScope::User => {
+        // Non-interactive SSH sessions have no XDG_RUNTIME_DIR, so the bridge can't find the
+        // user bus without help. Requires a running user manager (active session or lingering).
+        // The remote shell word-splits ssh's command string, so the -c payload must be quoted;
+        // $(id -u) is expanded by the remote sh, not locally.
+        args.push("sh".into());
+        args.push("-c".into());
+        args.push("'XDG_RUNTIME_DIR=/run/user/$(id -u) exec systemd-stdio-bridge --user'".into());
+      },
+    }
+    args
+  }
+
+  /// Build a `std::process::Command` that runs `program args...` on the remote host.
+  pub fn command(&self, program: &str, args: &[&str]) -> Command {
+    let mut cmd = Command::new("ssh");
+    self.add_remote_invocation(&mut cmd, program, args);
+    cmd
+  }
+
+  /// Like [`SshHost::command`] but for tokio.
+  pub fn tokio_command(&self, program: &str, args: &[&str]) -> tokio::process::Command {
+    let mut cmd = tokio::process::Command::new("ssh");
+    let mut std_cmd = Command::new("ssh");
+    self.add_remote_invocation(&mut std_cmd, program, args);
+    cmd.args(std_cmd.get_args());
+    cmd
+  }
+
+  fn add_remote_invocation(&self, cmd: &mut Command, program: &str, args: &[&str]) {
+    cmd.arg("-xT");
+    cmd.args(self.mux_options());
+    cmd.arg("--");
+    cmd.arg(&self.host);
+    // ssh concatenates arguments and hands them to the remote shell, so quote each one
+    cmd.arg(shell_quote(program));
+    for arg in args {
+      cmd.arg(shell_quote(arg));
+    }
+  }
+}
+
+/// Single-quote a string for a POSIX shell.
+fn shell_quote(s: &str) -> String {
+  if !s.is_empty() && s.chars().all(|c| c.is_ascii_alphanumeric() || "-_./=:@%+,".contains(c)) {
+    return s.to_string();
+  }
+  format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+/// Run `program args...` locally, or on the remote host if `--host` was given.
+pub fn host_command(program: &str, args: &[&str]) -> Command {
+  match remote_host() {
+    Some(ssh_host) => ssh_host.command(program, args),
+    None => {
+      let mut cmd = Command::new(program);
+      cmd.args(args);
+      cmd
+    },
+  }
+}
+
+/// Tokio version of [`host_command`].
+pub fn host_tokio_command(program: &str, args: &[&str]) -> tokio::process::Command {
+  match remote_host() {
+    Some(ssh_host) => ssh_host.tokio_command(program, args),
+    None => {
+      let mut cmd = tokio::process::Command::new(program);
+      cmd.args(args);
+      cmd
+    },
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_shell_quote_plain() {
+    assert_eq!(shell_quote("docker.service"), "docker.service");
+    assert_eq!(shell_quote("--lines=500"), "--lines=500");
+  }
+
+  #[test]
+  fn test_shell_quote_special() {
+    assert_eq!(shell_quote("foo bar"), "'foo bar'");
+    assert_eq!(shell_quote("it's"), r"'it'\''s'");
+    assert_eq!(shell_quote(""), "''");
+  }
+}

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -90,6 +90,9 @@ impl SshHost {
   pub fn command(&self, program: &str, args: &[&str]) -> Command {
     let mut cmd = Command::new("ssh");
     self.add_remote_invocation(&mut cmd, program, args);
+    // ssh forwards its stdin to the remote command; if it inherits the TUI's stdin it
+    // steals keystrokes from the terminal
+    cmd.stdin(std::process::Stdio::null());
     cmd
   }
 
@@ -99,6 +102,8 @@ impl SshHost {
     let mut std_cmd = Command::new("ssh");
     self.add_remote_invocation(&mut std_cmd, program, args);
     cmd.args(std_cmd.get_args());
+    // same stdin-stealing hazard as in `command` above
+    cmd.stdin(std::process::Stdio::null());
     cmd
   }
 

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -754,7 +754,20 @@ pub fn check_unit_has_run(unit: &UnitId) -> bool {
 /// Returns a diagnostic if something is wrong. Deliberately not using --quiet:
 /// journalctl succeeds with empty output when the user can only see their own
 /// entries, and the warning on stderr is the only signal.
+/// Cached per scope: access won't change mid-session (group changes need a new
+/// login), and on remote hosts each check costs an SSH round trip.
 fn check_journal_access(scope: UnitScope) -> Option<LogDiagnostic> {
+  static GLOBAL_ACCESS: std::sync::OnceLock<Option<LogDiagnostic>> = std::sync::OnceLock::new();
+  static USER_ACCESS: std::sync::OnceLock<Option<LogDiagnostic>> = std::sync::OnceLock::new();
+
+  let cell = match scope {
+    UnitScope::Global => &GLOBAL_ACCESS,
+    UnitScope::User => &USER_ACCESS,
+  };
+  cell.get_or_init(|| check_journal_access_uncached(scope)).clone()
+}
+
+fn check_journal_access_uncached(scope: UnitScope) -> Option<LogDiagnostic> {
   let mut args = vec!["--lines=1"];
   if scope == UnitScope::User {
     args.push("--user");

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,13 +1,14 @@
 // File initially taken from https://github.com/servicer-labs/servicer/blob/master/src/utils/systemd.rs, since modified
 
 use core::str;
-use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 use log::error;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use zbus::{proxy, zvariant, Connection};
+
+use crate::ssh;
 
 #[derive(Debug, Clone)]
 pub struct UnitWithStatus {
@@ -155,8 +156,8 @@ pub async fn get_unit_files(scope: Scope, services: &[String]) -> Result<Vec<Uni
       Ok(conn) => conn,
       Err(e) => {
         error!("get_unit_files: failed to get {:?} connection: {:?}", unit_scope, e);
-        if is_root && unit_scope == UnitScope::User {
-          info!("get_unit_files: skipping user scope because we're root");
+        if (is_root || ssh::remote_host().is_some()) && unit_scope == UnitScope::User {
+          info!("get_unit_files: skipping user scope");
           continue;
         }
         return Err(e);
@@ -171,8 +172,8 @@ pub async fn get_unit_files(scope: Scope, services: &[String]) -> Result<Vec<Uni
         },
         Err(e) => {
           error!("get_unit_files: list_unit_files_by_patterns failed for {:?}: {:?}", unit_scope, e);
-          if is_root && unit_scope == UnitScope::User {
-            info!("get_unit_files: ignoring user scope error because we're root");
+          if (is_root || ssh::remote_host().is_some()) && unit_scope == UnitScope::User {
+            info!("get_unit_files: ignoring user scope error");
             vec![]
           } else {
             return Err(e.into());
@@ -218,12 +219,17 @@ pub async fn get_all_services(scope: Scope, services: &[String]) -> Result<Vec<U
       units.extend(system_units?);
 
       // Should always be able to get user units, but it may fail when running as root
-      if let Ok(user_units) = user_units {
-        units.extend(user_units);
-      } else if is_root {
-        error!("Failed to get user units, ignoring because we're running as root")
-      } else {
-        user_units?;
+      // or when the remote host has no running user manager
+      match user_units {
+        Ok(user_units) => units.extend(user_units),
+        Err(e) if is_root => error!("Failed to get user units, ignoring because we're running as root: {e:?}"),
+        Err(e) if ssh::remote_host().is_some() => {
+          error!(
+            "Failed to get user units from remote host: {e:?}. \
+             This requires an active session or lingering (loginctl enable-linger) on the remote host."
+          )
+        },
+        Err(e) => return Err(e),
       }
     },
   }
@@ -253,7 +259,7 @@ pub fn get_unit_file_location(service: &UnitId) -> Result<String> {
     args.insert(0, "--user");
   }
 
-  let output = Command::new("systemctl").args(&args).output()?;
+  let output = ssh::host_command("systemctl", &args).output()?;
 
   if output.status.success() {
     let path = str::from_utf8(&output.stdout)?.trim();
@@ -329,10 +335,38 @@ pub async fn reload(scope: UnitScope, cancel_token: CancellationToken) -> Result
 }
 
 async fn get_connection(scope: UnitScope) -> Result<Connection, anyhow::Error> {
-  match scope {
-    UnitScope::Global => Ok(Connection::system().await?),
-    UnitScope::User => Ok(Connection::session().await?),
-  }
+  // Cache connections; this matters a lot for remote hosts, where each new connection
+  // spawns an ssh + systemd-stdio-bridge pair
+  static GLOBAL_CONNECTION: tokio::sync::OnceCell<Connection> = tokio::sync::OnceCell::const_new();
+  static USER_CONNECTION: tokio::sync::OnceCell<Connection> = tokio::sync::OnceCell::const_new();
+
+  let cell = match scope {
+    UnitScope::Global => &GLOBAL_CONNECTION,
+    UnitScope::User => &USER_CONNECTION,
+  };
+
+  let connection = cell
+    .get_or_try_init(|| async {
+      match ssh::remote_host() {
+        Some(ssh_host) => {
+          let unixexec = zbus::address::transport::Unixexec::new(
+            std::path::PathBuf::from("ssh"),
+            Some(std::ffi::OsString::from("ssh")),
+            ssh_host.bridge_ssh_args(scope),
+          );
+          let connection =
+            zbus::connection::Builder::address(zbus::address::Transport::Unixexec(unixexec))?.build().await?;
+          info!("Established remote D-Bus connection to {} for {:?} scope", ssh_host.host, scope);
+          Ok::<Connection, anyhow::Error>(connection)
+        },
+        None => match scope {
+          UnitScope::Global => Ok(Connection::system().await?),
+          UnitScope::User => Ok(Connection::session().await?),
+        },
+      }
+    })
+    .await?;
+  Ok(connection.clone())
 }
 
 pub async fn restart_service(service: UnitId, cancel_token: CancellationToken) -> Result<()> {
@@ -426,7 +460,7 @@ pub async fn kill_service(service: UnitId, signal: String, cancel_token: Cancell
     }
     args.push(&service.name);
 
-    let output = Command::new("systemctl").args(&args).output()?;
+    let output = ssh::host_command("systemctl", &args).output()?;
 
     if output.status.success() {
       info!("Successfully sent signal {} to srvice {}", signal, service.name);
@@ -695,8 +729,7 @@ pub fn check_unit_has_run(unit: &UnitId) -> bool {
   }
   args.push(&unit.name);
 
-  Command::new("systemctl")
-    .args(&args)
+  ssh::host_command("systemctl", &args)
     .output()
     .ok()
     .and_then(
@@ -713,7 +746,7 @@ fn can_access_journal(scope: UnitScope) -> Result<(), String> {
     args.push("--user");
   }
 
-  match Command::new("journalctl").args(&args).output() {
+  match ssh::host_command("journalctl", &args).output() {
     Ok(output) => {
       if output.status.success() {
         Ok(())

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -700,6 +700,8 @@ pub enum LogDiagnostic {
   PermissionDenied { error: String },
   /// Journal is available but no logs exist for this unit
   NoLogsRecorded { unit_name: String },
+  /// The user can only see their own journal entries, not system-wide ones
+  LimitedJournalAccess,
   /// journalctl command failed with an error
   JournalctlError { stderr: String },
 }
@@ -715,6 +717,15 @@ impl LogDiagnostic {
       Self::PermissionDenied { error } => format!("Permission denied: {}\n\nTry: sudo systemctl-tui", error),
       Self::NoLogsRecorded { unit_name } => {
         format!("No logs recorded for {} (unit has run but produced no journal output)", unit_name)
+      },
+      Self::LimitedJournalAccess => {
+        let place = match crate::ssh::remote_host() {
+          Some(ssh_host) => format!(" on {}", ssh_host.host),
+          None => String::new(),
+        };
+        format!(
+          "No access to system logs: this user can only see its own journal entries.\n\nTo fix, run{place}: sudo usermod -aG systemd-journal $USER\n(takes effect on next login)"
+        )
       },
       Self::JournalctlError { stderr } => format!("journalctl error: {}", stderr),
     }
@@ -739,23 +750,35 @@ pub fn check_unit_has_run(unit: &UnitId) -> bool {
     .unwrap_or(false)
 }
 
-/// Check if the journal is accessible at all (tests general read access)
-fn can_access_journal(scope: UnitScope) -> Result<(), String> {
-  let mut args = vec!["--lines=1", "--quiet"];
+/// Check whether the journal is readable and we can see system-wide entries.
+/// Returns a diagnostic if something is wrong. Deliberately not using --quiet:
+/// journalctl succeeds with empty output when the user can only see their own
+/// entries, and the warning on stderr is the only signal.
+fn check_journal_access(scope: UnitScope) -> Option<LogDiagnostic> {
+  let mut args = vec!["--lines=1"];
   if scope == UnitScope::User {
     args.push("--user");
   }
 
   match ssh::host_command("journalctl", &args).output() {
     Ok(output) => {
+      let stderr = String::from_utf8_lossy(&output.stderr);
+      if scope == UnitScope::Global && journalctl_warns_about_limited_access(&stderr) {
+        return Some(LogDiagnostic::LimitedJournalAccess);
+      }
       if output.status.success() {
-        Ok(())
+        None
       } else {
-        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+        Some(parse_journalctl_error(stderr.trim()))
       }
     },
-    Err(e) => Err(e.to_string()),
+    Err(e) => Some(LogDiagnostic::JournalInaccessible { error: e.to_string() }),
   }
+}
+
+/// Does this journalctl stderr contain the warning about only seeing your own messages?
+pub fn journalctl_warns_about_limited_access(stderr: &str) -> bool {
+  stderr.contains("Users in groups") || stderr.contains("not seeing messages from other users")
 }
 
 /// Parse journalctl stderr to determine the specific error type
@@ -773,14 +796,15 @@ pub fn parse_journalctl_error(stderr: &str) -> LogDiagnostic {
 
 /// Diagnose why logs are missing for a unit
 pub fn diagnose_missing_logs(unit: &UnitId) -> LogDiagnostic {
-  // Check 1: Has unit ever run?
-  if !check_unit_has_run(unit) {
-    return LogDiagnostic::NeverRun { unit_name: unit.name.clone() };
+  // Check 1: Can we read the journal at all? Do this first: without access,
+  // every unit looks like it has no logs and other checks are misleading
+  if let Some(diagnostic) = check_journal_access(unit.scope) {
+    return diagnostic;
   }
 
-  // Check 2: Can we access the journal at all?
-  if let Err(error) = can_access_journal(unit.scope) {
-    return parse_journalctl_error(&error);
+  // Check 2: Has the unit ever run?
+  if !check_unit_has_run(unit) {
+    return LogDiagnostic::NeverRun { unit_name: unit.name.clone() };
   }
 
   // If we get here, journal is accessible but no logs for this specific unit
@@ -812,6 +836,17 @@ mod tests {
   fn test_parse_journalctl_error_no_file() {
     let diagnostic = parse_journalctl_error("No such file or directory");
     assert!(matches!(diagnostic, LogDiagnostic::JournalInaccessible { .. }));
+  }
+
+  #[test]
+  fn test_limited_access_warning_detection() {
+    // real journalctl output from a user not in adm/systemd-journal (systemd 249)
+    let stderr = "Hint: You are currently not seeing messages from other users and the system.\n      \
+                  Users in groups 'adm', 'systemd-journal' can see all messages.\n      \
+                  Pass -q to turn off this notice.";
+    assert!(journalctl_warns_about_limited_access(stderr));
+    assert!(!journalctl_warns_about_limited_access("-- No entries --"));
+    assert!(!journalctl_warns_about_limited_access(""));
   }
 
   #[test]

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -235,7 +235,7 @@ pub async fn get_all_services(scope: Scope, services: &[String]) -> Result<Vec<U
   }
 
   // sort by name case-insensitive
-  units.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+  units.sort_by_key(|a| a.name.to_lowercase());
 
   info!("Loaded systemd services in {:?}", start.elapsed());
 


### PR DESCRIPTION
**Thought I'd see how Fable did with the very tricky #45 . Handled it well!**

This was written by Claude Code+Fable, with thorough review+input by me.

------


Closes #45. You can now manage systemd on a remote machine without installing anything extra on it:

```
systemctl-tui --host user@hostname
```

This picks up where the old `remote` branch left off. That branch proved the D-Bus side works (zbus's `unixexec` transport running `systemd-stdio-bridge` over ssh, like `systemctl --host` does), but got stuck on two things: logs, and user-scope services. Both turned out to have workable answers.

## Deets

1. Everything shares one multiplexed SSH connection. At startup (before entering the TUI, so password/2FA prompts work) we establish a ControlMaster connection; every later ssh — D-Bus bridges and `journalctl` calls — reuses it via ControlPath, so each one is a cheap channel open instead of a full handshake. Each instance gets its own master (our PID is in the ControlPath), the initial connection times out after 10s instead of hanging on firewalled hosts, and we check that `systemd-stdio-bridge` exists on the remote host up front so a non-systemd machine fails with a clear error before the TUI starts. Thanks @kainctl for suggesting the multiplexing approach in the issue thread.
2. Logs come from running `journalctl` on the remote host over ssh. We already shell out to `journalctl` locally for both the batch fetch and follow mode, so remote is the same command with an ssh prefix. Fetches take roughly 100-200ms per unit on my LAN. When a unit has no logs we diagnose why (including a missing `systemd-journal` group membership); that check is cached per scope since it costs an SSH round trip.
3. User-scope services work now. `systemd-stdio-bridge --user` was the wall here — on my test host it silently served the system bus (I noticed because the global and user unit counts were suspiciously identical). Passing the socket path explicitly with `-p unix:path=/run/user/$(id -u)/bus` fixes it (that flag exists back to at least systemd 239, and I've tested 249 and 255). This needs a running user manager on the remote host (an active session or `loginctl enable-linger`); if there is none we fall back to system units only.
4. D-Bus connections are cached per scope, since each new remote connection spawns an ssh + bridge pair.
5. Editing unit files is disabled for remote hosts (the file lives on the other machine). Viewing the path still works.

Actions on system-scope units need the remote user to be root or have a polkit rule; otherwise polkit rejects them with "Interactive authentication required" and we show that error. There is no way to do an interactive polkit prompt over the bridge.

One bug worth calling out because it was fun: the ssh processes spawned for journalctl inherited the TUI's stdin, and ssh forwards stdin to the remote command. So any key pressed while a log fetch was in flight got eaten by ssh — typing in the search box dropped characters constantly. Fixed by nulling stdin on the wrapped ssh commands.

## Testing performed

Tested against two real remote hosts (a Pi and a server on my LAN, systemd 255 and 249):

- browse services, view details and remote unit file paths
- historical logs plus follow mode (watched Stopped/Started lines stream in live during a restart)
- restarted a user-scope service through the TUI and confirmed the state change on the host
- system-scope action correctly rejected by remote polkit and surfaced as an error dialog
- keystroke-drop regression test: scripted 30ms and 10ms interval typing over tmux, 0 drops after the stdin fix (4/5 runs dropped keys before)
- clean exit tears down the ssh master connection
- bad hostname fails fast with a clean error before entering the TUI
- local mode unaffected (full tmux test battery passes)

## Regression tests

After testing on a second host surfaced more issues, I added tests at three levels:

1. Unit tests asserting the exact ssh argv we build (mux options, quoting, both bridge invocations). These would have caught the `sh -c` quoting bug.
2. `scripts/integration-test.py` drives the real binary in tmux and asserts on captured screen content — the AGENTS.md manual test checklist, automated. It tests local systemd by default; `--host user@hostname` runs the same tests in remote mode, including a scripted-typing regression test for the stdin bug. 12/12 locally and against two real hosts.
3. A CI job runs the harness in both modes: against local systemd, and in `--host` mode against sshd on the runner itself (GitHub runners run real systemd).

The second host also found a diagnostics bug: if your user is not in `adm`/`systemd-journal`, `journalctl --quiet` exits 0 with empty output and every service showed "never been started". The diagnostic now checks journal access first (without `--quiet`, whose only effect was hiding the warning that explains the problem) and suggests the `usermod` fix.

## Future work

- remote unit file viewing/editing (could fetch via ssh)
- reconnecting if the ssh connection drops mid-session (cached connections do not recover right now)

While I was in the area I also fixed 4 pre-existing clippy warnings — the latest stable clippy flags them, and CI uses `-D warnings`, so they were about to break every PR.




