### PR TITLE
Show runtime info in the details pane

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ fuzzy-matcher = "0.3"
 itertools = "0.14.0"
 indexmap = "2.0.0"
 clipboard-anywhere = "0.2.2"
-chrono = { version = "0.4.31", default-features = false }
+chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 lazy_static = "1.4.0"
 nix = { version = "0.31.0", features = ["user"] }
 is-wsl = "0.4.0"

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,6 +1,6 @@
 use crate::{
   components::home::Mode,
-  systemd::{ServiceList, UnitFile, UnitId},
+  systemd::{ServiceList, UnitFile, UnitId, UnitRuntimeInfo},
 };
 
 #[derive(Debug, Clone)]
@@ -22,6 +22,7 @@ pub enum Action {
   CancelTask,
   ToggleHelp,
   SetUnitFilePath { unit: UnitId, path: Result<String, String> },
+  SetUnitRuntimeInfo { unit: UnitId, info: Box<UnitRuntimeInfo> },
   CopyUnitFilePath,
   SetLogs { unit: UnitId, logs: Vec<String> },
   AppendLogLine { unit: UnitId, line: String },

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -24,7 +24,10 @@ use std::{process::Stdio, time::Duration};
 use super::{logger::Logger, Component, Frame};
 use crate::{
   action::Action,
-  systemd::{self, diagnose_missing_logs, parse_journalctl_error, Scope, UnitFile, UnitId, UnitScope, UnitWithStatus},
+  systemd::{
+    self, diagnose_missing_logs, parse_journalctl_error, Scope, UnitFile, UnitId, UnitRuntimeInfo, UnitScope,
+    UnitWithStatus,
+  },
 };
 
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -96,6 +99,8 @@ pub struct Home {
   pub filtered_units: StatefulList<MatchedUnit>,
   pub logs: Vec<String>,
   pub logs_scroll_offset: u16,
+  /// Runtime info for the currently selected unit, fetched lazily after selection
+  pub runtime_info: Option<UnitRuntimeInfo>,
   pub mode: Mode,
   pub previous_mode: Option<Mode>,
   pub input: Input,
@@ -287,6 +292,7 @@ impl Home {
 
   pub fn next(&mut self) {
     self.logs = vec![];
+    self.runtime_info = None;
     self.filtered_units.next();
     self.get_logs();
     self.logs_scroll_offset = 0;
@@ -294,6 +300,7 @@ impl Home {
 
   pub fn previous(&mut self) {
     self.logs = vec![];
+    self.runtime_info = None;
     self.filtered_units.previous();
     self.get_logs();
     self.logs_scroll_offset = 0;
@@ -302,6 +309,7 @@ impl Home {
   pub fn select(&mut self, index: Option<usize>, refresh_logs: bool) {
     if refresh_logs {
       self.logs = vec![];
+      self.runtime_info = None;
     }
     self.filtered_units.select(index);
     if refresh_logs {
@@ -312,6 +320,7 @@ impl Home {
 
   pub fn unselect(&mut self) {
     self.logs = vec![];
+    self.runtime_info = None;
     self.filtered_units.unselect();
   }
 
@@ -515,10 +524,16 @@ impl Component for Home {
         // lazy debounce to avoid spamming journalctl on slow connections/systems
         std::thread::sleep(Duration::from_millis(100));
 
-        // get the unit file path
-        match systemd::get_unit_file_location(&unit) {
-          Ok(path) => {
-            let _ = tx.send(Action::SetUnitFilePath { unit: unit.clone(), path: Ok(path) });
+        // get the unit file path + runtime info (one systemctl call for both)
+        match systemd::get_unit_runtime_info(&unit) {
+          Ok(info) => {
+            let path = if info.fragment_path.is_empty() {
+              Err("could not be determined".into())
+            } else {
+              Ok(info.fragment_path.clone())
+            };
+            let _ = tx.send(Action::SetUnitFilePath { unit: unit.clone(), path });
+            let _ = tx.send(Action::SetUnitRuntimeInfo { unit: unit.clone(), info: Box::new(info) });
             let _ = tx.send(Action::Render);
           },
           Err(e) => {
@@ -526,7 +541,7 @@ impl Component for Home {
             let _ =
               tx.send(Action::SetUnitFilePath { unit: unit.clone(), path: Err("could not be determined".into()) });
             let _ = tx.send(Action::Render);
-            error!("Error getting unit file path for {}: {}", unit.name, e);
+            error!("Error getting unit info for {}: {}", unit.name, e);
           },
         }
 
@@ -857,6 +872,13 @@ impl Component for Home {
         }
         self.refresh_filtered_units(); // copy the updated unit file path to the filtered list
       },
+      Action::SetUnitRuntimeInfo { unit, info } => {
+        if let Some(selected) = self.filtered_units.selected() {
+          if selected.unit.id() == unit {
+            self.runtime_info = Some(*info);
+          }
+        }
+      },
       Action::SetLogs { unit, logs } => {
         if let Some(selected) = self.filtered_units.selected() {
           if selected.unit.id() == unit {
@@ -1056,52 +1078,44 @@ impl Component for Home {
 
     let selected_item = self.filtered_units.selected();
 
-    let right_panel =
-      Layout::new(Direction::Vertical, [Constraint::Min(8), Constraint::Percentage(100)]).split(right_panel);
-    let details_panel = right_panel[0];
-    let logs_panel = right_panel[1];
+    // Details rows: base unit facts on the left, runtime stats (fetched lazily on selection)
+    // in a second column on wide terminals, or folded into a single "Runtime" row otherwise.
+    let dim = Style::default().add_modifier(Modifier::DIM);
+    let mut rows: Vec<(&str, Line)> = vec![];
+    let mut stat_rows: Vec<(&str, Line)> = vec![];
 
-    let details_block = Block::default().title("─Details").borders(Borders::ALL).border_type(BorderType::Rounded);
-    let details_panel_panes = Layout::new(Direction::Horizontal, [Constraint::Min(14), Constraint::Percentage(100)])
-      .split(details_block.inner(details_panel));
-    let props_pane = details_panel_panes[0];
-    let values_pane = details_panel_panes[1];
-
-    let props_lines = vec![
-      Line::from("Description: "),
-      Line::from("Enablement: "),
-      Line::from("Scope: "),
-      Line::from("Loaded: "),
-      Line::from("Active: "),
-      Line::from("Unit file: "),
-    ];
-
-    let details_text = if let Some(m) = selected_item {
-      fn line_color_string<'a>(value: String, color: Color) -> Line<'a> {
-        Line::from(vec![Span::styled(value, Style::default().fg(color))])
-      }
-
-      let load_color = match m.unit.load_state.as_str() {
-        "loaded" => Color::Green,
-        "not-found" => Color::Yellow,
-        "error" => Color::Red,
-        _ => Color::Reset,
-      };
+    if let Some(m) = selected_item {
+      rows.push(("Description", Line::from(m.unit.description.as_str())));
 
       let active_color = match m.unit.activation_state.as_str() {
         "active" => Color::Green,
-        "inactive" => Color::Reset,
         "failed" => Color::Red,
         _ => Color::Reset,
       };
+      let mut active_spans = vec![Span::styled(
+        format!("{} ({})", m.unit.activation_state, m.unit.sub_state),
+        Style::default().fg(active_color),
+      )];
+      if let Some(info) = &self.runtime_info {
+        if m.unit.activation_state == "failed" {
+          if let Some(result) = info.result.as_deref().filter(|r| *r != "success") {
+            let status = info.exec_main_status.filter(|&s| s != 0).map(|s| format!(", status={s}")).unwrap_or_default();
+            active_spans.push(Span::styled(format!(" ({result}{status})"), Style::default().fg(Color::Red)));
+          }
+        }
+        let since = if m.unit.activation_state == "active" {
+          info.active_enter_timestamp.as_deref()
+        } else {
+          info.inactive_enter_timestamp.as_deref()
+        };
+        if let Some((absolute, relative)) = since.and_then(format_systemd_timestamp) {
+          let relative = relative.map(|r| format!(" ({r})")).unwrap_or_default();
+          active_spans.push(Span::styled(format!(" since {absolute}{relative}"), dim));
+        }
+      }
+      rows.push(("Active", Line::from(active_spans)));
 
-      let active_state_value = format!("{} ({})", m.unit.activation_state, m.unit.sub_state);
-
-      let scope = match m.unit.scope {
-        UnitScope::Global => "Global",
-        UnitScope::User => "User",
-      };
-
+      // Enablement, scope, and any load problem share a line
       let enablement_state = m.unit.enablement_state.as_deref().unwrap_or("");
       let enablement_color = match enablement_state {
         "enabled" => Color::Green,
@@ -1109,32 +1123,116 @@ impl Component for Home {
         "masked" => Color::Red,
         _ => Color::Reset,
       };
+      let scope = match m.unit.scope {
+        UnitScope::Global => "global",
+        UnitScope::User => "user",
+      };
+      let mut state_spans = vec![
+        Span::styled(enablement_state, Style::default().fg(enablement_color)),
+        Span::styled(format!(" · {scope}"), dim),
+      ];
+      if m.unit.load_state != "loaded" {
+        let load_color = match m.unit.load_state.as_str() {
+          "not-found" => Color::Yellow,
+          "error" | "masked" | "bad-setting" => Color::Red,
+          _ => Color::Reset,
+        };
+        state_spans.push(Span::styled(format!(" · {}", m.unit.load_state), Style::default().fg(load_color)));
+      }
+      rows.push(("Enablement", Line::from(state_spans)));
 
-      let lines = vec![
-        colored_line(&m.unit.description, Color::Reset),
-        colored_line(enablement_state, enablement_color),
-        colored_line(scope, Color::Reset),
-        colored_line(&m.unit.load_state, load_color),
-        line_color_string(active_state_value, active_color),
+      rows.push((
+        "Unit file",
         match &m.unit.file_path {
           Some(Ok(file_path)) => Line::from(file_path.as_str()),
           Some(Err(e)) => colored_line(e, Color::Red),
           None => Line::from(""),
         },
-      ];
+      ));
 
-      lines
+      if let Some(info) = &self.runtime_info {
+        if let Some(pid) = info.main_pid {
+          stat_rows.push(("PID", Line::from(pid.to_string())));
+        }
+        if let Some(memory) = info.memory_current {
+          stat_rows.push(("Memory", Line::from(format_bytes(memory))));
+        }
+        if let Some(tasks) = info.tasks_current {
+          stat_rows.push(("Tasks", Line::from(tasks.to_string())));
+        }
+        if let Some(cpu) = info.cpu_usage_nsec.filter(|&n| n > 0) {
+          stat_rows.push(("CPU", Line::from(format_cpu_nsec(cpu))));
+        }
+        if let Some(restarts) = info.n_restarts.filter(|&n| n > 0) {
+          stat_rows
+            .push(("Restarts", Line::from(Span::styled(restarts.to_string(), Style::default().fg(Color::Yellow)))));
+        }
+        if let Some((absolute, relative)) = info.next_elapse.as_deref().and_then(format_systemd_timestamp) {
+          let relative = relative.map(|r| format!(" ({r})")).unwrap_or_default();
+          stat_rows.push(("Next run", Line::from(format!("{absolute}{relative}"))));
+        }
+      }
+    }
+
+    let two_columns = right_panel.width >= 90 && !stat_rows.is_empty();
+    if !two_columns && !stat_rows.is_empty() {
+      // Narrow terminal: fold the stats into one line to save vertical space
+      let mut spans: Vec<Span> = vec![];
+      for (i, (label, line)) in stat_rows.drain(..).enumerate() {
+        if i > 0 {
+          spans.push(Span::styled(" · ", dim));
+        }
+        spans.push(Span::styled(format!("{label} "), dim));
+        spans.extend(line.spans);
+      }
+      rows.push(("Runtime", Line::from(spans)));
+    }
+
+    // Size the details panel to its content instead of a fixed height
+    let details_content_height = rows.len().max(stat_rows.len()).max(1) as u16;
+    let right_panel =
+      Layout::new(Direction::Vertical, [Constraint::Length(details_content_height + 2), Constraint::Percentage(100)])
+        .split(right_panel);
+    let details_panel = right_panel[0];
+    let logs_panel = right_panel[1];
+
+    let details_block = Block::default().title("─Details").borders(Borders::ALL).border_type(BorderType::Rounded);
+    let details_inner = details_block.inner(details_panel);
+    f.render_widget(details_block, details_panel);
+
+    fn label_width(rows: &[(&str, Line)]) -> u16 {
+      rows.iter().map(|(label, _)| label.len() + 2).max().unwrap_or(0) as u16
+    }
+
+    fn split_labels_values<'a>(rows: Vec<(&'a str, Line<'a>)>) -> (Vec<Line<'a>>, Vec<Line<'a>>) {
+      rows.into_iter().map(|(label, value)| (Line::from(format!("{label}: ")), value)).unzip()
+    }
+
+    let panes = if two_columns {
+      Layout::new(
+        Direction::Horizontal,
+        [
+          Constraint::Length(label_width(&rows)),
+          Constraint::Fill(2),
+          Constraint::Length(label_width(&stat_rows) + 1),
+          Constraint::Fill(1),
+        ],
+      )
+      .split(details_inner)
     } else {
-      vec![]
+      Layout::new(Direction::Horizontal, [Constraint::Length(label_width(&rows)), Constraint::Fill(1)])
+        .split(details_inner)
     };
 
-    let paragraph = Paragraph::new(details_text).style(Style::default());
+    let (labels, values) = split_labels_values(rows);
+    f.render_widget(Paragraph::new(labels).alignment(ratatui::layout::Alignment::Right), panes[0]);
+    f.render_widget(Paragraph::new(values), panes[1]);
 
-    let props_widget = Paragraph::new(props_lines).alignment(ratatui::layout::Alignment::Right);
-    f.render_widget(props_widget, props_pane);
-
-    f.render_widget(paragraph, values_pane);
-    f.render_widget(details_block, details_panel);
+    if two_columns {
+      let (stat_labels, stat_values) = split_labels_values(stat_rows);
+      f.render_widget(Paragraph::new(stat_labels).alignment(ratatui::layout::Alignment::Right), panes[2]);
+      f.render_widget(Paragraph::new(stat_values), panes[3]);
+    }
 
     let log_lines = self
       .logs
@@ -1347,6 +1445,58 @@ impl Component for Home {
 ///
 /// systemd v255 changed the timestamp format from `-0700` to `-07:00` (RFC 3339).
 /// See: https://github.com/systemd/systemd/pull/29134
+/// Parses a systemd "show" timestamp like "Wed 2026-07-08 10:00:00 PDT" into a compact
+/// absolute form ("2026-07-08 10:00") and a relative one ("2d 4h ago" or "in 2d 4h").
+/// The relative part assumes the host clock/timezone roughly match ours, which can be
+/// slightly off in remote mode — good enough for a human-scale "how long ago".
+fn format_systemd_timestamp(timestamp: &str) -> Option<(String, Option<String>)> {
+  let mut parts = timestamp.split_whitespace();
+  let _weekday = parts.next()?;
+  let date = parts.next()?;
+  let time = parts.next()?;
+  let naive = chrono::NaiveDateTime::parse_from_str(&format!("{date} {time}"), "%Y-%m-%d %H:%M:%S").ok()?;
+  let absolute = naive.format("%Y-%m-%d %H:%M").to_string();
+  let seconds = chrono::Local::now().naive_local().signed_duration_since(naive).num_seconds();
+  let relative = if seconds >= 0 {
+    format!("{} ago", format_duration(seconds as u64))
+  } else {
+    format!("in {}", format_duration(seconds.unsigned_abs()))
+  };
+  Some((absolute, Some(relative)))
+}
+
+fn format_duration(seconds: u64) -> String {
+  match seconds {
+    s if s < 60 => format!("{s}s"),
+    s if s < 3600 => format!("{}m {}s", s / 60, s % 60),
+    s if s < 86400 => format!("{}h {}m", s / 3600, (s % 3600) / 60),
+    s => format!("{}d {}h", s / 86400, (s % 86400) / 3600),
+  }
+}
+
+fn format_bytes(bytes: u64) -> String {
+  const UNITS: [&str; 5] = ["B", "K", "M", "G", "T"];
+  let mut value = bytes as f64;
+  let mut unit = 0;
+  while value >= 1024.0 && unit < UNITS.len() - 1 {
+    value /= 1024.0;
+    unit += 1;
+  }
+  if unit == 0 {
+    format!("{bytes}B")
+  } else {
+    format!("{value:.1}{}", UNITS[unit])
+  }
+}
+
+fn format_cpu_nsec(nsec: u64) -> String {
+  if nsec < 1_000_000_000 {
+    format!("{}ms", nsec / 1_000_000)
+  } else {
+    format_duration(nsec / 1_000_000_000)
+  }
+}
+
 fn parse_journalctl_timestamp(timestamp: &str) -> Option<String> {
   // %z accepts both "-0700" (systemd <v255) and "-07:00" (systemd >=v255)
   DateTime::parse_from_str(timestamp, "%Y-%m-%dT%H:%M:%S%z").ok().map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -267,9 +267,31 @@ async fn get_services(scope: UnitScope, services: &[String]) -> Result<Vec<UnitW
   Ok(units)
 }
 
-pub fn get_unit_file_location(service: &UnitId) -> Result<String> {
-  // show -P FragmentPath reitunes.service
-  let mut args = vec!["--quiet", "show", "-P", "FragmentPath"];
+/// Runtime properties for a single unit, fetched on demand when it's selected.
+/// All fields are optional because they vary by unit type (services have PIDs,
+/// timers have a next elapse, etc.) and by systemd version.
+#[derive(Debug, Clone, Default)]
+pub struct UnitRuntimeInfo {
+  pub fragment_path: String,
+  pub main_pid: Option<u32>,
+  pub memory_current: Option<u64>,
+  pub tasks_current: Option<u64>,
+  pub n_restarts: Option<u32>,
+  pub cpu_usage_nsec: Option<u64>,
+  pub active_enter_timestamp: Option<String>,
+  pub inactive_enter_timestamp: Option<String>,
+  pub result: Option<String>,
+  pub exec_main_status: Option<i32>,
+  pub next_elapse: Option<String>,
+}
+
+/// Fetches runtime properties (including the unit file path) for a unit in a single
+/// `systemctl show` invocation. Uses systemctl rather than D-Bus so it works in remote mode too.
+/// Properties that don't apply to the unit type are simply omitted from the output.
+pub fn get_unit_runtime_info(service: &UnitId) -> Result<UnitRuntimeInfo> {
+  const PROPERTIES: &str = "FragmentPath,MainPID,MemoryCurrent,TasksCurrent,NRestarts,CPUUsageNSec,\
+                            ActiveEnterTimestamp,InactiveEnterTimestamp,Result,ExecMainStatus,NextElapseUSecRealtime";
+  let mut args = vec!["--quiet", "show", "-p", PROPERTIES];
   args.push(&service.name);
 
   if service.scope == UnitScope::User {
@@ -278,16 +300,40 @@ pub fn get_unit_file_location(service: &UnitId) -> Result<String> {
 
   let output = ssh::host_command("systemctl", &args).output()?;
 
-  if output.status.success() {
-    let path = str::from_utf8(&output.stdout)?.trim();
-    if path.is_empty() {
-      bail!("No unit file found for {}", service.name);
-    }
-    Ok(path.trim().to_string())
-  } else {
+  if !output.status.success() {
     let stderr = String::from_utf8(output.stderr)?;
     bail!(stderr);
   }
+
+  fn non_empty(value: &str) -> Option<String> {
+    match value {
+      "" | "[not set]" | "n/a" => None,
+      v => Some(v.to_string()),
+    }
+  }
+
+  let mut info = UnitRuntimeInfo::default();
+  for line in str::from_utf8(&output.stdout)?.lines() {
+    let Some((key, value)) = line.split_once('=') else { continue };
+    let value = value.trim();
+    match key {
+      "FragmentPath" => info.fragment_path = value.to_string(),
+      "MainPID" => info.main_pid = value.parse().ok().filter(|&pid| pid != 0),
+      // systemd prints u64::MAX (or "[not set]") for unavailable accounting values
+      "MemoryCurrent" => info.memory_current = value.parse().ok().filter(|&v| v != u64::MAX),
+      "TasksCurrent" => info.tasks_current = value.parse().ok().filter(|&v| v != u64::MAX),
+      "NRestarts" => info.n_restarts = value.parse().ok(),
+      "CPUUsageNSec" => info.cpu_usage_nsec = value.parse().ok().filter(|&v| v != u64::MAX),
+      "ActiveEnterTimestamp" => info.active_enter_timestamp = non_empty(value),
+      "InactiveEnterTimestamp" => info.inactive_enter_timestamp = non_empty(value),
+      "Result" => info.result = non_empty(value),
+      "ExecMainStatus" => info.exec_main_status = value.parse().ok(),
+      "NextElapseUSecRealtime" => info.next_elapse = non_empty(value),
+      _ => {},
+    }
+  }
+
+  Ok(info)
 }
 
 pub async fn start_service(service: UnitId, cancel_token: CancellationToken) -> Result<()> {

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -207,7 +207,8 @@ def test_user_bus_is_user_bus(binary: str, host: str) -> None:
     time.sleep(1)
     result_screen = capture()
     check("sctui-user-test.service selected", "sctui-user-test.service" in result_screen, result_screen)
-    check("scope shows User", "User" in result_screen, result_screen)
+    # scope is shown on the Enablement line, e.g. "disabled · user"
+    check("scope shows user", "· user" in result_screen, result_screen)
 
 
 def test_root_action_round_trip(binary: str, root_host: str) -> None:


### PR DESCRIPTION
The details pane was the least information-dense part of the screen: 6 fixed rows restating mostly static facts (description, enablement, scope, load state, active state, unit file path), with nothing about what the service is actually doing right now.

This PR makes it show live runtime info and adapt to the terminal size:

1. When you select a unit, we now fetch runtime properties with a single `systemctl show` call: PID, memory, tasks, CPU time, restart count, active/inactive timestamps, failure result, and next elapse for timers. This reuses the existing lazy `FragmentPath` fetch (it is the same call now, so no extra round-trip) and works in remote mode too, since it goes through `systemctl` rather than D-Bus.
2. The Active row gained the good stuff: `active (running) since 2026-07-08 18:53 (3d 4h ago)`, and failed units show the result inline, like `(exit-code, status=1)`.
3. Scope and load state folded into the Enablement row (`enabled · user`, with load problems like `not-found` appended in color), so the base pane is down to 4 rows.
4. On wide terminals the runtime stats get a second column: PID / Memory / Tasks / CPU / Restarts / Next run, each shown only when it applies. Timers show `Next run: 2026-07-12 07:30 (in 7h 40m)`, which I'm pretty pleased with.
5. On narrow terminals the stats fold into one row: `Runtime: PID 1123 · Memory 4.7M · Tasks 1 · CPU 1m 51s`.
6. The pane height is now dynamic instead of fixed at 8 rows, so units with less to report give the reclaimed space to the logs.

Caveats: the "ago"/"in" math assumes the host clock and timezone roughly match ours, so it can be off for remote hosts in another timezone (the absolute timestamp is shown regardless). Stats are a snapshot at selection time; they don't tick live. I also enabled chrono's `clock` feature to compute relative times.

## Before

```
│Description: D-Bus System Message Bus
│ Enablement: static
│      Scope: Global
│     Loaded: loaded
│     Active: active (running)
│  Unit file: /usr/lib/systemd/system/dbus.service
```

## After

Wide terminal:

```
│Description: D-Bus System Message Bus                               PID: 1123
│     Active: active (running) since 2026-07-08 18:53 (3d 4h ago) Memory: 4.7M
│ Enablement: static · global                                      Tasks: 1
│  Unit file: /usr/lib/systemd/system/dbus.service                   CPU: 1m 51s
```

Narrow terminal:

```
│Description: D-Bus System Message Bus
│     Active: active (running) since 2026-07-08 18:53 (3d 4h ago)
│ Enablement: static · global
│  Unit file: /usr/lib/systemd/system/dbus.service
│    Runtime: PID 1123 · Memory 4.7M · Tasks 1 · CPU 1m 51s
```

## Testing performed

Drove it in tmux at 160 and 100 columns: running service (two-column stats), inactive service (`since ... ago` from the inactive timestamp), masked unit, and timers (`--limit-units "*.timer"`, Next run row). `cargo fmt`, `cargo clippy`, and `cargo test` all pass.