### PR TITLE
Add mouse support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ name = "systemctl-tui"
 version = "0.5.2"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "better-panic",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,23 +98,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "x11rb",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,12 +160,6 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -338,28 +315,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clipboard-anywhere"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106a1a29f5e2b2ff402e5edc89222367833a75e67194797351e3746e12eab12b"
-dependencies = [
- "anyhow",
- "arboard",
- "base64 0.13.1",
- "duct",
- "is-wsl",
-]
-
-[[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
 
 [[package]]
 name = "colorchoice"
@@ -598,34 +553,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
-]
-
-[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
-]
-
-[[package]]
-name = "duct"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
-dependencies = [
- "libc",
- "once_cell",
- "os_pipe",
- "shared_child",
 ]
 
 [[package]]
@@ -692,12 +625,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "euclid"
@@ -910,16 +837,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "gethostname"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
-dependencies = [
- "rustix",
- "windows-link",
 ]
 
 [[package]]
@@ -1352,79 +1269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-app-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-graphics",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.11.0",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags 2.11.0",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,16 +1315,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,12 +1342,6 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1953,32 +1781,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "sigchld",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "sigchld"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
-dependencies = [
- "libc",
- "os_pipe",
- "signal-hook 0.3.18",
-]
 
 [[package]]
 name = "signal-hook"
@@ -2109,11 +1915,10 @@ name = "systemctl-tui"
 version = "0.5.2"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "better-panic",
  "chrono",
  "clap",
- "clipboard-anywhere",
  "crossterm",
  "directories",
  "futures",
@@ -2202,7 +2007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.0",
  "fancy-regex",
  "filedescriptor",
@@ -2857,16 +2662,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2884,31 +2680,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2918,22 +2697,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2942,22 +2709,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2966,22 +2721,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2990,22 +2733,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3112,23 +2843,6 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
-
-[[package]]
-name = "x11rb"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
-dependencies = [
- "gethostname",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xterm-query"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ratatui = "0.30.0"
+ratatui = { version = "0.30.0", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.29.0", default-features = false, features = ["event-stream"] }
 tokio = { version = "1.28.2", features = ["full"] }
 unicode-segmentation = "1.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ zbus = { version = "5", default-features = false, features = ["tokio"] }
 fuzzy-matcher = "0.3"
 itertools = "0.14.0"
 indexmap = "2.0.0"
-clipboard-anywhere = "0.2.2"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 lazy_static = "1.4.0"
 nix = { version = "0.31.0", features = ["user"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ nix = { version = "0.31.0", features = ["user"] }
 is-wsl = "0.4.0"
 tracing-appender = "0.2.3"
 terminal-light = "1"
+base64 = "0.22"
 
 # build with `cargo build --profile profiling`
 # to analyze performance with tooling like perf / samply / superluminal

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -1082,11 +1082,8 @@ impl Component for Home {
         self.logs_scroll_offset = 0;
       },
       Action::ScrollToBottom => {
-        // TODO: this is partially broken, figure out a better way to scroll to end
-        // problem: we don't actually know the height of the paragraph before it's rendered
-        // because it's wrapped based on the width of the widget
-        // A proper fix might need to wait until ratatui improves scrolling: https://github.com/ratatui-org/ratatui/issues/174
-        self.logs_scroll_offset = self.logs.len() as u16;
+        // Clamped to the actual wrapped height at render time (see `render`).
+        self.logs_scroll_offset = u16::MAX;
       },
 
       Action::StartService(service_name) => self.start_service(service_name),
@@ -1437,8 +1434,16 @@ impl Component for Home {
     let paragraph = Paragraph::new(log_lines)
       .block(Block::default().title("─Service Logs").borders(Borders::ALL).border_type(BorderType::Rounded))
       .style(Style::default())
-      .wrap(Wrap { trim: true })
-      .scroll((self.logs_scroll_offset, 0));
+      .wrap(Wrap { trim: true });
+
+    // line_count wraps at the given width but includes the block's border rows in its count,
+    // so wrap at the inner width and compare against the full panel height.
+    let inner_width = logs_panel.width.saturating_sub(2);
+    let total_lines = u16::try_from(paragraph.line_count(inner_width)).unwrap_or(u16::MAX);
+    let max_offset = total_lines.saturating_sub(logs_panel.height);
+    self.logs_scroll_offset = self.logs_scroll_offset.min(max_offset);
+
+    let paragraph = paragraph.scroll((self.logs_scroll_offset, 0));
     f.render_widget(paragraph, logs_panel);
 
     let width = search_panel.width.max(3) - 3; // keep 2 for borders and 1 for cursor

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -472,12 +472,9 @@ impl Home {
   }
 
   fn copy_with_toast(&mut self, text: &str) {
-    // Belt and suspenders: OSC 52 works over SSH but not in all terminals; the native clipboard
-    // works in all terminals but not over SSH.
-    crate::utils::copy_to_clipboard_osc52(text);
-    let _ = clipboard_anywhere::set_clipboard(text);
+    crate::utils::copy_to_clipboard(text);
     let n = text.chars().count();
-    self.show_toast(&format!("Copied {n} chars via OSC 52"));
+    self.show_toast(&format!("Copied {n} chars"));
   }
 
   fn show_toast(&mut self, msg: &str) {

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -235,6 +235,11 @@ pub struct Home {
   pub search_panel: Rect,
   /// A transient toast message and when it was shown.
   pub toast: Option<(String, std::time::Instant)>,
+  /// Screen rects of each filter item line in the status filter popup, paired with the filter
+  /// index they correspond to, as of the most recent render. Empty when the popup isn't shown.
+  pub filter_item_rects: Vec<(Rect, usize)>,
+  /// Area of the status filter popup, as of the most recent render.
+  pub filter_popup_rect: Rect,
 }
 
 pub struct MenuItem {
@@ -1028,6 +1033,52 @@ impl Component for Home {
     }
 
     let pos = Position::new(mouse.column, mouse.row);
+
+    if self.mode == Mode::StatusFilter {
+      let hovered_item = self.filter_item_rects.iter().find(|(rect, _)| rect.contains(pos)).map(|(_, idx)| *idx);
+
+      return match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+          if let Some(idx) = hovered_item {
+            self.filter_cursor = idx;
+            self.toggle_filtered_status(UnitStatus::ALL[idx]);
+            vec![Action::RefreshStatusFilterMenu]
+          } else if !self.filter_popup_rect.contains(pos) {
+            // Clicked outside the popup: close it, same as Escape.
+            vec![Action::EnterMode(Mode::ServiceList)]
+          } else {
+            // Clicked inside the popup but not on an item (e.g. a category header).
+            vec![]
+          }
+        },
+        MouseEventKind::Moved => {
+          if let Some(idx) = hovered_item {
+            if idx != self.filter_cursor {
+              self.filter_cursor = idx;
+              return vec![Action::RefreshStatusFilterMenu];
+            }
+          }
+          vec![]
+        },
+        MouseEventKind::ScrollDown => {
+          if self.filter_cursor < UnitStatus::ALL.len() - 1 {
+            self.filter_cursor += 1;
+          } else {
+            self.filter_cursor = 0;
+          }
+          vec![Action::RefreshStatusFilterMenu]
+        },
+        MouseEventKind::ScrollUp => {
+          if self.filter_cursor > 0 {
+            self.filter_cursor -= 1;
+          } else {
+            self.filter_cursor = UnitStatus::ALL.len() - 1;
+          }
+          vec![Action::RefreshStatusFilterMenu]
+        },
+        _ => vec![],
+      };
+    }
 
     fn clamp_into(rect: Rect, pos: Position) -> Position {
       if rect.width == 0 || rect.height == 0 {
@@ -1839,15 +1890,18 @@ impl Component for Home {
 
     let popup_width = min_width.min(f.area().width);
 
+    self.filter_item_rects.clear();
     if self.mode == Mode::StatusFilter {
       // Custom grouped layout for the status filter popup
       let mut lines: Vec<Line> = Vec::new();
+      let mut line_item_indices: Vec<Option<usize>> = Vec::new();
       let mut idx = 0;
       for (category_name, filters) in STATUS_CATEGORIES {
         lines.push(Line::from(Span::styled(
           *category_name,
           Style::default().fg(theme.muted).add_modifier(Modifier::BOLD),
         )));
+        line_item_indices.push(None);
         for filter in *filters {
           let is_checked = self.filtered_statuses.contains(filter);
           let is_selected = idx == self.filter_cursor;
@@ -1864,6 +1918,7 @@ impl Component for Home {
           } else {
             lines.push(Line::from(line_spans));
           }
+          line_item_indices.push(Some(idx));
           idx += 1;
         }
       }
@@ -1871,6 +1926,15 @@ impl Component for Home {
       let filter_popup_width = 20u16.min(f.area().width);
       let height = lines.len() as u16 + 2;
       let popup = f.area().centered(Constraint::Length(filter_popup_width), Constraint::Length(height));
+      self.filter_popup_rect = popup;
+
+      for (i, item_idx) in line_item_indices.iter().enumerate() {
+        if let Some(item_idx) = item_idx {
+          let rect =
+            Rect { x: popup.x + 1, y: popup.y + 1 + i as u16, width: popup.width.saturating_sub(2), height: 1 };
+          self.filter_item_rects.push((rect, *item_idx));
+        }
+      }
 
       let paragraph = Paragraph::new(lines).block(
         Block::default()

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -228,8 +228,9 @@ pub struct Home {
   pub selected_log_text: String,
   /// Most recent mouse position, in absolute screen coordinates.
   pub mouse_position: Position,
-  /// Area of the unit file path line in the details pane, as of the most recent render.
-  pub file_path_rect: Rect,
+  /// Copyable fields in the details pane (rect on screen -> full text to copy), as of the most
+  /// recent render.
+  pub copyable_fields: Vec<(Rect, String)>,
   /// Area of the search input panel, as of the most recent render.
   pub search_panel: Rect,
   /// A transient toast message and when it was shown.
@@ -456,6 +457,16 @@ impl Home {
     self.selected_log_text.clear();
   }
 
+  fn hovered_field(&self, pos: Position) -> Option<usize> {
+    self.copyable_fields.iter().position(|(rect, _)| rect.contains(pos))
+  }
+
+  fn copy_with_toast(&mut self, text: &str) {
+    crate::utils::copy_to_clipboard_osc52(text);
+    let n = text.chars().count();
+    self.show_toast(&format!("Copied {n} chars via OSC 52"));
+  }
+
   fn show_toast(&mut self, msg: &str) {
     self.toast = Some((msg.to_string(), std::time::Instant::now()));
     if let Some(tx) = self.action_tx.clone() {
@@ -463,6 +474,27 @@ impl Home {
         tokio::time::sleep(std::time::Duration::from_millis(2100)).await;
         let _ = tx.send(Action::Render);
       });
+    }
+  }
+
+  /// Draw the transient copy toast in the bottom-right corner. Must be called at the very end of
+  /// `render` so nothing draws over it.
+  fn render_toast(&mut self, f: &mut Frame<'_>) {
+    if let Some((msg, shown_at)) = &self.toast {
+      if shown_at.elapsed() < std::time::Duration::from_secs(2) {
+        let area = f.area();
+        let width = msg.len() as u16 + 2;
+        if area.width > width && area.height > 1 {
+          let toast_rect =
+            Rect { x: area.right().saturating_sub(width), y: area.bottom().saturating_sub(1), width, height: 1 };
+          let paragraph = Paragraph::new(Line::from(format!(" {msg} ")))
+            .style(Style::default().fg(self.theme.accent).add_modifier(Modifier::REVERSED));
+          f.render_widget(Clear, toast_rect);
+          f.render_widget(paragraph, toast_rect);
+        }
+      } else {
+        self.toast = None;
+      }
     }
   }
 
@@ -1008,9 +1040,9 @@ impl Component for Home {
 
     match mouse.kind {
       MouseEventKind::Moved => {
-        let was_hovering = self.file_path_rect.contains(self.mouse_position);
+        let was_hovering = self.hovered_field(self.mouse_position);
         self.mouse_position = pos;
-        let is_hovering = self.file_path_rect.contains(pos);
+        let is_hovering = self.hovered_field(pos);
         if was_hovering != is_hovering {
           vec![Action::Render]
         } else {
@@ -1042,14 +1074,10 @@ impl Component for Home {
       },
       MouseEventKind::Down(MouseButton::Left) => {
         self.mouse_position = pos;
-        if self.file_path_rect.contains(pos) {
-          if let Some(m) = self.filtered_units.selected() {
-            if let Some(Ok(path)) = &m.unit.file_path {
-              crate::utils::copy_to_clipboard_osc52(path);
-              self.show_toast("Copied to clipboard");
-              return vec![Action::Render];
-            }
-          }
+        if let Some(idx) = self.hovered_field(pos) {
+          let text = self.copyable_fields[idx].1.clone();
+          self.copy_with_toast(&text);
+          return vec![Action::Render];
         }
         if self.search_panel.contains(pos) && self.mode == Mode::ServiceList {
           return vec![Action::EnterMode(Mode::Search)];
@@ -1090,8 +1118,8 @@ impl Component for Home {
         self.mouse_position = pos;
         if let Some((anchor, cursor)) = self.logs_selection {
           if anchor != cursor && !self.selected_log_text.is_empty() {
-            crate::utils::copy_to_clipboard_osc52(&self.selected_log_text);
-            self.show_toast("Copied to clipboard");
+            let text = self.selected_log_text.clone();
+            self.copy_with_toast(&text);
           } else {
             self.clear_logs_selection();
           }
@@ -1421,8 +1449,6 @@ impl Component for Home {
     let dim = Style::default().add_modifier(Modifier::DIM);
     let mut rows: Vec<(&str, Line)> = vec![];
     let mut stat_rows: Vec<(&str, Line)> = vec![];
-    // Row index and display width of the unit file path, if shown; used for mouse hit-testing.
-    let mut file_path_row: Option<(usize, u16)> = None;
 
     if let Some(m) = selected_item {
       rows.push(("Description", Line::from(m.unit.description.as_str())));
@@ -1481,20 +1507,10 @@ impl Component for Home {
       }
       rows.push(("Enablement", Line::from(state_spans)));
 
-      // Hover state is tested against the previous frame's rect; the rect itself is updated
-      // below once the details layout is known.
-      let file_path_style = if self.file_path_rect.contains(self.mouse_position) {
-        Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
-      } else {
-        Style::default()
-      };
-      if let Some(Ok(file_path)) = &m.unit.file_path {
-        file_path_row = Some((rows.len(), file_path.len() as u16));
-      }
       rows.push((
         "Unit file",
         match &m.unit.file_path {
-          Some(Ok(file_path)) => Line::from(Span::styled(file_path.as_str(), file_path_style)),
+          Some(Ok(file_path)) => Line::from(file_path.as_str()),
           Some(Err(e)) => Line::from(Span::styled(e.as_str(), Style::default().fg(Color::Red))),
           None => Line::from(""),
         },
@@ -1574,19 +1590,34 @@ impl Component for Home {
         .split(details_inner)
     };
 
-    let (labels, values) = split_labels_values(rows);
+    // Every details value line (and runtime stat line) is hoverable and click-to-copy. Register
+    // each rendered line's rect and text, bolding the hovered one.
+    self.copyable_fields.clear();
+    fn register_copyable_fields(values: &mut [Line], pane: Rect, mouse: Position, out: &mut Vec<(Rect, String)>) {
+      for (i, line) in values.iter_mut().enumerate() {
+        if i as u16 >= pane.height {
+          break;
+        }
+        let text = line.spans.iter().map(|s| s.content.as_ref()).collect::<String>().trim().to_string();
+        if text.is_empty() {
+          continue;
+        }
+        let rect = Rect { x: pane.x, y: pane.y + i as u16, width: (line.width() as u16).min(pane.width), height: 1 };
+        if rect.contains(mouse) {
+          line.style = line.style.add_modifier(Modifier::BOLD);
+        }
+        out.push((rect, text));
+      }
+    }
+
+    let (labels, mut values) = split_labels_values(rows);
+    register_copyable_fields(&mut values, panes[1], self.mouse_position, &mut self.copyable_fields);
     f.render_widget(Paragraph::new(labels).alignment(ratatui::layout::Alignment::Right), panes[0]);
     f.render_widget(Paragraph::new(values), panes[1]);
 
-    self.file_path_rect = match file_path_row {
-      Some((idx, width)) if (idx as u16) < panes[1].height => {
-        Rect { x: panes[1].x, y: panes[1].y + idx as u16, width: width.min(panes[1].width), height: 1 }
-      },
-      _ => Rect::ZERO,
-    };
-
     if two_columns {
-      let (stat_labels, stat_values) = split_labels_values(stat_rows);
+      let (stat_labels, mut stat_values) = split_labels_values(stat_rows);
+      register_copyable_fields(&mut stat_values, panes[3], self.mouse_position, &mut self.copyable_fields);
       f.render_widget(Paragraph::new(stat_labels).alignment(ratatui::layout::Alignment::Right), panes[2]);
       f.render_widget(Paragraph::new(stat_values), panes[3]);
     }
@@ -1765,25 +1796,6 @@ impl Component for Home {
       f.render_widget(paragraph, popup);
     }
 
-    if let Some((msg, shown_at)) = &self.toast {
-      let elapsed = shown_at.elapsed();
-      if elapsed < std::time::Duration::from_secs(2) {
-        let area = f.area();
-        let width = msg.len() as u16 + 2;
-        if area.width > width + 1 && area.height > 2 {
-          let toast_rect =
-            Rect { x: area.right().saturating_sub(width + 1), y: area.bottom().saturating_sub(2), width, height: 1 };
-          let toast_text = format!(" {msg} ");
-          let paragraph = Paragraph::new(Line::from(toast_text))
-            .style(Style::default().fg(theme.accent).add_modifier(Modifier::REVERSED));
-          f.render_widget(Clear, toast_rect);
-          f.render_widget(paragraph, toast_rect);
-        }
-      } else {
-        self.toast = None;
-      }
-    }
-
     let selected_unit_name = match self.filtered_units.selected() {
       Some(s) => &s.unit.name,
       None => "",
@@ -1927,6 +1939,8 @@ impl Component for Home {
       f.render_widget(Clear, popup);
       f.render_widget(paragraph, popup);
     }
+
+    self.render_toast(f);
   }
 }
 

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -1,11 +1,11 @@
 use chrono::DateTime;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use futures::Future;
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use ratatui::{
-  layout::{Constraint, Direction, Layout, Rect},
+  layout::{Constraint, Direction, Layout, Position, Rect},
   style::{Color, Modifier, Style},
   text::{Line, Span},
   widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
@@ -217,6 +217,15 @@ pub struct Home {
   pub fuzzy_matcher: SkimMatcherV2,
   pub filtered_statuses: HashSet<UnitStatus>,
   pub filter_cursor: usize,
+  /// Inner (border-excluded) area of the logs panel, as of the most recent render.
+  pub logs_panel_inner: Rect,
+  /// Area of the services list panel, as of the most recent render.
+  pub services_panel: Rect,
+  /// Active mouse-drag text selection in the logs panel: (anchor, cursor), in absolute screen
+  /// coordinates.
+  pub logs_selection: Option<(Position, Position)>,
+  /// Text extracted from the current `logs_selection`, computed at render time.
+  pub selected_log_text: String,
 }
 
 pub struct MenuItem {
@@ -403,6 +412,7 @@ impl Home {
     self.filtered_units.next();
     self.get_logs();
     self.logs_scroll_offset = 0;
+    self.clear_logs_selection();
   }
 
   pub fn previous(&mut self) {
@@ -411,6 +421,7 @@ impl Home {
     self.filtered_units.previous();
     self.get_logs();
     self.logs_scroll_offset = 0;
+    self.clear_logs_selection();
   }
 
   pub fn select(&mut self, index: Option<usize>, refresh_logs: bool) {
@@ -422,6 +433,7 @@ impl Home {
     if refresh_logs {
       self.get_logs();
       self.logs_scroll_offset = 0;
+      self.clear_logs_selection();
     }
   }
 
@@ -429,6 +441,11 @@ impl Home {
     self.logs = vec![];
     self.runtime_info = None;
     self.filtered_units.unselect();
+  }
+
+  fn clear_logs_selection(&mut self) {
+    self.logs_selection = None;
+    self.selected_log_text.clear();
   }
 
   pub fn selected_service(&self) -> Option<UnitId> {
@@ -781,6 +798,10 @@ impl Component for Home {
     match self.mode {
       Mode::ServiceList => {
         match key.code {
+          KeyCode::Esc if self.logs_selection.is_some() => {
+            self.clear_logs_selection();
+            vec![Action::Render]
+          },
           KeyCode::Char('q') => vec![Action::Quit],
           KeyCode::Up | KeyCode::Char('k') => {
             // if we're filtering the list, and we're at the top, and there's text in the search box, go to search mode
@@ -950,6 +971,73 @@ impl Component for Home {
     }
   }
 
+  fn handle_mouse_events(&mut self, mouse: MouseEvent) -> Vec<Action> {
+    let pos = Position::new(mouse.column, mouse.row);
+
+    fn contains(rect: Rect, pos: Position) -> bool {
+      pos.x >= rect.x && pos.x < rect.x + rect.width && pos.y >= rect.y && pos.y < rect.y + rect.height
+    }
+
+    fn clamp_into(rect: Rect, pos: Position) -> Position {
+      if rect.width == 0 || rect.height == 0 {
+        return Position::new(rect.x, rect.y);
+      }
+      let x = pos.x.clamp(rect.x, rect.x + rect.width - 1);
+      let y = pos.y.clamp(rect.y, rect.y + rect.height - 1);
+      Position::new(x, y)
+    }
+
+    match mouse.kind {
+      MouseEventKind::ScrollUp => {
+        self.clear_logs_selection();
+        if contains(self.services_panel, pos) {
+          if self.filtered_units.state.selected() == Some(0) {
+            return vec![Action::EnterMode(Mode::Search)];
+          }
+          self.previous();
+          vec![Action::Render]
+        } else {
+          vec![Action::ScrollUp(2), Action::Render]
+        }
+      },
+      MouseEventKind::ScrollDown => {
+        self.clear_logs_selection();
+        if contains(self.services_panel, pos) {
+          self.next();
+          vec![Action::Render]
+        } else {
+          vec![Action::ScrollDown(2), Action::Render]
+        }
+      },
+      MouseEventKind::Down(MouseButton::Left) => {
+        if contains(self.logs_panel_inner, pos) {
+          self.logs_selection = Some((pos, pos));
+        } else {
+          self.clear_logs_selection();
+        }
+        vec![Action::Render]
+      },
+      MouseEventKind::Drag(MouseButton::Left) => {
+        if let Some((anchor, _)) = self.logs_selection {
+          let clamped = clamp_into(self.logs_panel_inner, pos);
+          self.logs_selection = Some((anchor, clamped));
+        }
+        vec![Action::Render]
+      },
+      MouseEventKind::Up(MouseButton::Left) => {
+        if let Some((anchor, cursor)) = self.logs_selection {
+          if anchor != cursor && !self.selected_log_text.is_empty() {
+            crate::utils::copy_to_clipboard_osc52(&self.selected_log_text);
+          } else {
+            self.clear_logs_selection();
+          }
+        }
+        vec![Action::Render]
+      },
+      _ => vec![],
+    }
+  }
+
   fn dispatch(&mut self, action: Action) -> Option<Action> {
     match action {
       Action::ToggleShowLogger => {
@@ -1073,17 +1161,21 @@ impl Component for Home {
       Action::ScrollUp(offset) => {
         self.logs_scroll_offset = self.logs_scroll_offset.saturating_sub(offset);
         info!("scroll offset: {}", self.logs_scroll_offset);
+        self.clear_logs_selection();
       },
       Action::ScrollDown(offset) => {
         self.logs_scroll_offset = self.logs_scroll_offset.saturating_add(offset);
         info!("scroll offset: {}", self.logs_scroll_offset);
+        self.clear_logs_selection();
       },
       Action::ScrollToTop => {
         self.logs_scroll_offset = 0;
+        self.clear_logs_selection();
       },
       Action::ScrollToBottom => {
         // Clamped to the actual wrapped height at render time (see `render`).
         self.logs_scroll_offset = u16::MAX;
+        self.clear_logs_selection();
       },
 
       Action::StartService(service_name) => self.start_service(service_name),
@@ -1251,6 +1343,8 @@ impl Component for Home {
     let chunks =
       Layout::new(Direction::Horizontal, [Constraint::Min(30), Constraint::Percentage(100)]).split(main_panel);
     let right_panel = chunks[1];
+
+    self.services_panel = chunks[0];
 
     f.render_stateful_widget(items, chunks[0], &mut self.filtered_units.state);
 
@@ -1446,6 +1540,59 @@ impl Component for Home {
     let paragraph = paragraph.scroll((self.logs_scroll_offset, 0));
     f.render_widget(paragraph, logs_panel);
 
+    // Inner area of the logs panel (border-excluded), used for mouse hit-testing and selection.
+    self.logs_panel_inner = Rect {
+      x: logs_panel.x.saturating_add(1),
+      y: logs_panel.y.saturating_add(1),
+      width: logs_panel.width.saturating_sub(2),
+      height: logs_panel.height.saturating_sub(2),
+    };
+
+    if let Some((anchor, cursor)) = self.logs_selection {
+      let inner = self.logs_panel_inner;
+      // Normalize selection ordering by (y, then x).
+      let (start, end) = if (anchor.y, anchor.x) <= (cursor.y, cursor.x) { (anchor, cursor) } else { (cursor, anchor) };
+
+      let buf = f.buffer_mut();
+      let mut selected_rows: Vec<String> = Vec::new();
+
+      if inner.width > 0 && inner.height > 0 {
+        let left = inner.x;
+        let right = inner.x + inner.width - 1;
+
+        for y in start.y..=end.y {
+          if y < inner.y || y >= inner.y + inner.height {
+            continue;
+          }
+
+          let (row_start_x, row_end_x) = if start.y == end.y {
+            (start.x.max(left), end.x.min(right))
+          } else if y == start.y {
+            (start.x.max(left), right)
+          } else if y == end.y {
+            (left, end.x.min(right))
+          } else {
+            (left, right)
+          };
+
+          if row_start_x > row_end_x {
+            continue;
+          }
+
+          let mut row_text = String::new();
+          for x in row_start_x..=row_end_x {
+            if let Some(cell) = buf.cell_mut(Position::new(x, y)) {
+              cell.modifier.insert(Modifier::REVERSED);
+              row_text.push_str(cell.symbol());
+            }
+          }
+          selected_rows.push(row_text.trim_end().to_string());
+        }
+      }
+
+      self.selected_log_text = selected_rows.join("\n");
+    }
+
     let width = search_panel.width.max(3) - 3; // keep 2 for borders and 1 for cursor
     let scroll = self.input.visual_scroll(width as usize);
     let input = Paragraph::new(self.input.value())
@@ -1485,7 +1632,7 @@ impl Component for Home {
     }
 
     if self.mode == Mode::Help {
-      let popup = f.area().centered(Constraint::Length(50), Constraint::Length(18));
+      let popup = f.area().centered(Constraint::Length(50), Constraint::Length(19));
 
       let primary = |s| Span::styled(s, Style::default().fg(theme.primary));
       let help_lines = vec![
@@ -1499,6 +1646,7 @@ impl Component for Home {
         Line::from(vec![primary("Enter"), Span::raw(" or "), primary("Space"), Span::raw(" open the action menu")]),
         Line::from(vec![primary("f"), Span::raw(" filter services by status")]),
         Line::from(vec![primary("?"), Span::raw(" / "), primary("F1"), Span::raw(" open this help pane")]),
+        Line::from(vec![primary("mouse"), Span::raw(": drag to select+copy logs, wheel to scroll")]),
         Line::from(""),
         Line::from(Span::styled("Vim Style Shortcuts", Style::default().add_modifier(Modifier::UNDERLINED))),
         Line::from(""),

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -185,6 +185,11 @@ impl Theme {
   }
 }
 
+/// Whether `pos` falls within `rect`.
+fn contains(rect: Rect, pos: Position) -> bool {
+  pos.x >= rect.x && pos.x < rect.x + rect.width && pos.y >= rect.y && pos.y < rect.y + rect.height
+}
+
 /// A unit with fuzzy match indices for highlighting
 #[derive(Clone)]
 pub struct MatchedUnit {
@@ -226,6 +231,12 @@ pub struct Home {
   pub logs_selection: Option<(Position, Position)>,
   /// Text extracted from the current `logs_selection`, computed at render time.
   pub selected_log_text: String,
+  /// Most recent mouse position, in absolute screen coordinates.
+  pub mouse_position: Position,
+  /// Area of the unit file path line in the details pane, as of the most recent render.
+  pub file_path_rect: Rect,
+  /// A transient toast message and when it was shown.
+  pub toast: Option<(String, std::time::Instant)>,
 }
 
 pub struct MenuItem {
@@ -446,6 +457,16 @@ impl Home {
   fn clear_logs_selection(&mut self) {
     self.logs_selection = None;
     self.selected_log_text.clear();
+  }
+
+  fn show_toast(&mut self, msg: &str) {
+    self.toast = Some((msg.to_string(), std::time::Instant::now()));
+    if let Some(tx) = self.action_tx.clone() {
+      tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(2100)).await;
+        let _ = tx.send(Action::Render);
+      });
+    }
   }
 
   pub fn selected_service(&self) -> Option<UnitId> {
@@ -974,10 +995,6 @@ impl Component for Home {
   fn handle_mouse_events(&mut self, mouse: MouseEvent) -> Vec<Action> {
     let pos = Position::new(mouse.column, mouse.row);
 
-    fn contains(rect: Rect, pos: Position) -> bool {
-      pos.x >= rect.x && pos.x < rect.x + rect.width && pos.y >= rect.y && pos.y < rect.y + rect.height
-    }
-
     fn clamp_into(rect: Rect, pos: Position) -> Position {
       if rect.width == 0 || rect.height == 0 {
         return Position::new(rect.x, rect.y);
@@ -988,7 +1005,18 @@ impl Component for Home {
     }
 
     match mouse.kind {
+      MouseEventKind::Moved => {
+        let was_hovering = contains(self.file_path_rect, self.mouse_position);
+        self.mouse_position = pos;
+        let is_hovering = contains(self.file_path_rect, pos);
+        if was_hovering != is_hovering {
+          vec![Action::Render]
+        } else {
+          vec![]
+        }
+      },
       MouseEventKind::ScrollUp => {
+        self.mouse_position = pos;
         self.clear_logs_selection();
         if contains(self.services_panel, pos) {
           if self.filtered_units.state.selected() == Some(0) {
@@ -1001,6 +1029,7 @@ impl Component for Home {
         }
       },
       MouseEventKind::ScrollDown => {
+        self.mouse_position = pos;
         self.clear_logs_selection();
         if contains(self.services_panel, pos) {
           self.next();
@@ -1010,6 +1039,16 @@ impl Component for Home {
         }
       },
       MouseEventKind::Down(MouseButton::Left) => {
+        self.mouse_position = pos;
+        if contains(self.file_path_rect, pos) {
+          if let Some(m) = self.filtered_units.selected() {
+            if let Some(Ok(path)) = &m.unit.file_path {
+              crate::utils::copy_to_clipboard_osc52(path);
+              self.show_toast("Copied to clipboard");
+              return vec![Action::Render];
+            }
+          }
+        }
         if contains(self.logs_panel_inner, pos) {
           self.logs_selection = Some((pos, pos));
         } else {
@@ -1018,6 +1057,7 @@ impl Component for Home {
         vec![Action::Render]
       },
       MouseEventKind::Drag(MouseButton::Left) => {
+        self.mouse_position = pos;
         if let Some((anchor, _)) = self.logs_selection {
           let clamped = clamp_into(self.logs_panel_inner, pos);
           self.logs_selection = Some((anchor, clamped));
@@ -1025,9 +1065,11 @@ impl Component for Home {
         vec![Action::Render]
       },
       MouseEventKind::Up(MouseButton::Left) => {
+        self.mouse_position = pos;
         if let Some((anchor, cursor)) = self.logs_selection {
           if anchor != cursor && !self.selected_log_text.is_empty() {
             crate::utils::copy_to_clipboard_osc52(&self.selected_log_text);
+            self.show_toast("Copied to clipboard");
           } else {
             self.clear_logs_selection();
           }
@@ -1355,6 +1397,8 @@ impl Component for Home {
     let dim = Style::default().add_modifier(Modifier::DIM);
     let mut rows: Vec<(&str, Line)> = vec![];
     let mut stat_rows: Vec<(&str, Line)> = vec![];
+    // Row index and display width of the unit file path, if shown; used for mouse hit-testing.
+    let mut file_path_row: Option<(usize, u16)> = None;
 
     if let Some(m) = selected_item {
       rows.push(("Description", Line::from(m.unit.description.as_str())));
@@ -1413,11 +1457,21 @@ impl Component for Home {
       }
       rows.push(("Enablement", Line::from(state_spans)));
 
+      // Hover state is tested against the previous frame's rect; the rect itself is updated
+      // below once the details layout is known.
+      let file_path_style = if contains(self.file_path_rect, self.mouse_position) {
+        Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+      } else {
+        Style::default()
+      };
+      if let Some(Ok(file_path)) = &m.unit.file_path {
+        file_path_row = Some((rows.len(), file_path.len() as u16));
+      }
       rows.push((
         "Unit file",
         match &m.unit.file_path {
-          Some(Ok(file_path)) => Line::from(file_path.as_str()),
-          Some(Err(e)) => colored_line(e, Color::Red),
+          Some(Ok(file_path)) => Line::from(Span::styled(file_path.as_str(), file_path_style)),
+          Some(Err(e)) => Line::from(Span::styled(e.as_str(), Style::default().fg(Color::Red))),
           None => Line::from(""),
         },
       ));
@@ -1499,6 +1553,13 @@ impl Component for Home {
     let (labels, values) = split_labels_values(rows);
     f.render_widget(Paragraph::new(labels).alignment(ratatui::layout::Alignment::Right), panes[0]);
     f.render_widget(Paragraph::new(values), panes[1]);
+
+    self.file_path_rect = match file_path_row {
+      Some((idx, width)) if (idx as u16) < panes[1].height => {
+        Rect { x: panes[1].x, y: panes[1].y + idx as u16, width: width.min(panes[1].width), height: 1 }
+      },
+      _ => Rect::ZERO,
+    };
 
     if two_columns {
       let (stat_labels, stat_values) = split_labels_values(stat_rows);
@@ -1683,6 +1744,25 @@ impl Component for Home {
 
       f.render_widget(Clear, popup);
       f.render_widget(paragraph, popup);
+    }
+
+    if let Some((msg, shown_at)) = &self.toast {
+      let elapsed = shown_at.elapsed();
+      if elapsed < std::time::Duration::from_secs(2) {
+        let area = f.area();
+        let width = msg.len() as u16 + 2;
+        if area.width > width + 1 && area.height > 2 {
+          let toast_rect =
+            Rect { x: area.right().saturating_sub(width + 1), y: area.bottom().saturating_sub(2), width, height: 1 };
+          let toast_text = format!(" {msg} ");
+          let paragraph = Paragraph::new(Line::from(toast_text))
+            .style(Style::default().fg(theme.accent).add_modifier(Modifier::REVERSED));
+          f.render_widget(Clear, toast_rect);
+          f.render_widget(paragraph, toast_rect);
+        }
+      } else {
+        self.toast = None;
+      }
     }
 
     let selected_unit_name = match self.filtered_units.selected() {

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -240,6 +240,11 @@ pub struct Home {
   pub filter_item_rects: Vec<(Rect, usize)>,
   /// Area of the status filter popup, as of the most recent render.
   pub filter_popup_rect: Rect,
+  /// Screen rects of each item line in the action/signal menu popup, paired with the item
+  /// index they correspond to, as of the most recent render. Empty when the popup isn't shown.
+  pub menu_item_rects: Vec<(Rect, usize)>,
+  /// Area of the action/signal menu popup, as of the most recent render.
+  pub menu_popup_rect: Rect,
 }
 
 pub struct MenuItem {
@@ -467,7 +472,10 @@ impl Home {
   }
 
   fn copy_with_toast(&mut self, text: &str) {
+    // Belt and suspenders: OSC 52 works over SSH but not in all terminals; the native clipboard
+    // works in all terminals but not over SSH.
     crate::utils::copy_to_clipboard_osc52(text);
+    let _ = clipboard_anywhere::set_clipboard(text);
     let n = text.chars().count();
     self.show_toast(&format!("Copied {n} chars via OSC 52"));
   }
@@ -1028,11 +1036,64 @@ impl Component for Home {
 
   fn handle_mouse_events(&mut self, mouse: MouseEvent) -> Vec<Action> {
     // In modal/transient modes, mouse events shouldn't affect selection or scrolling.
-    if matches!(self.mode, Mode::Help | Mode::ActionMenu | Mode::SignalMenu | Mode::Processing | Mode::Error) {
+    if matches!(self.mode, Mode::Processing) {
       return vec![];
     }
 
     let pos = Position::new(mouse.column, mouse.row);
+
+    if self.mode == Mode::Help {
+      return match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => vec![Action::ToggleHelp],
+        _ => vec![],
+      };
+    }
+
+    if self.mode == Mode::Error {
+      return match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => vec![Action::EnterMode(Mode::ServiceList)],
+        _ => vec![],
+      };
+    }
+
+    if self.mode == Mode::ActionMenu || self.mode == Mode::SignalMenu {
+      let hovered_item = self.menu_item_rects.iter().find(|(rect, _)| rect.contains(pos)).map(|(_, idx)| *idx);
+
+      return match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => {
+          if let Some(idx) = hovered_item {
+            self.menu_items.state.select(Some(idx));
+            match self.menu_items.selected() {
+              Some(i) => vec![i.action.clone()],
+              None => vec![Action::EnterMode(Mode::ServiceList)],
+            }
+          } else if !self.menu_popup_rect.contains(pos) {
+            // Clicked outside the popup: close it, same as Escape.
+            vec![Action::EnterMode(Mode::ServiceList)]
+          } else {
+            vec![]
+          }
+        },
+        MouseEventKind::Moved => {
+          if let Some(idx) = hovered_item {
+            if Some(idx) != self.menu_items.state.selected() {
+              self.menu_items.state.select(Some(idx));
+              return vec![Action::Render];
+            }
+          }
+          vec![]
+        },
+        MouseEventKind::ScrollDown => {
+          self.menu_items.next();
+          vec![Action::Render]
+        },
+        MouseEventKind::ScrollUp => {
+          self.menu_items.previous();
+          vec![Action::Render]
+        },
+        _ => vec![],
+      };
+    }
 
     if self.mode == Mode::StatusFilter {
       let hovered_item = self.filter_item_rects.iter().find(|(rect, _)| rect.contains(pos)).map(|(_, idx)| *idx);
@@ -1265,10 +1326,9 @@ impl Component for Home {
       Action::CopyUnitFilePath => {
         if let Some(selected) = self.filtered_units.selected() {
           if let Some(Ok(file_path)) = &selected.unit.file_path {
-            match clipboard_anywhere::set_clipboard(file_path) {
-              Ok(_) => return Some(Action::EnterMode(Mode::ServiceList)),
-              Err(e) => return Some(Action::EnterError(format!("Error copying to clipboard: {e}"))),
-            }
+            let file_path = file_path.clone();
+            self.copy_with_toast(&file_path);
+            return Some(Action::EnterMode(Mode::ServiceList));
           } else {
             return Some(Action::EnterError("No unit file path available".into()));
           }
@@ -1891,6 +1951,7 @@ impl Component for Home {
     let popup_width = min_width.min(f.area().width);
 
     self.filter_item_rects.clear();
+    self.menu_item_rects.clear();
     if self.mode == Mode::StatusFilter {
       // Custom grouped layout for the status filter popup
       let mut lines: Vec<Line> = Vec::new();
@@ -1956,6 +2017,7 @@ impl Component for Home {
       };
       let height = self.menu_items.items.len() as u16 + 2;
       let popup = f.area().centered(Constraint::Length(popup_width), Constraint::Length(height));
+      self.menu_popup_rect = popup;
 
       let items: Vec<ListItem> = self
         .menu_items
@@ -1976,6 +2038,19 @@ impl Component for Home {
             .title(title),
         )
         .highlight_style(Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD));
+
+      let offset = self.menu_items.state.offset();
+      for i in offset..self.menu_items.items.len() {
+        let rect = Rect {
+          x: popup.x + 1,
+          y: popup.y + 1 + (i - offset) as u16,
+          width: popup.width.saturating_sub(2),
+          height: 1,
+        };
+        if popup.height > 2 && rect.y < popup.y + popup.height - 1 {
+          self.menu_item_rects.push((rect, i));
+        }
+      }
 
       f.render_widget(Clear, popup);
       f.render_stateful_widget(items, popup, &mut self.menu_items.state);

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -5,7 +5,7 @@ use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use ratatui::{
-  layout::{Constraint, Direction, Layout, Position, Rect},
+  layout::{Constraint, Direction, Layout, Margin, Position, Rect},
   style::{Color, Modifier, Style},
   text::{Line, Span},
   widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
@@ -185,11 +185,6 @@ impl Theme {
   }
 }
 
-/// Whether `pos` falls within `rect`.
-fn contains(rect: Rect, pos: Position) -> bool {
-  pos.x >= rect.x && pos.x < rect.x + rect.width && pos.y >= rect.y && pos.y < rect.y + rect.height
-}
-
 /// A unit with fuzzy match indices for highlighting
 #[derive(Clone)]
 pub struct MatchedUnit {
@@ -235,6 +230,8 @@ pub struct Home {
   pub mouse_position: Position,
   /// Area of the unit file path line in the details pane, as of the most recent render.
   pub file_path_rect: Rect,
+  /// Area of the search input panel, as of the most recent render.
+  pub search_panel: Rect,
   /// A transient toast message and when it was shown.
   pub toast: Option<(String, std::time::Instant)>,
 }
@@ -993,6 +990,11 @@ impl Component for Home {
   }
 
   fn handle_mouse_events(&mut self, mouse: MouseEvent) -> Vec<Action> {
+    // In modal/transient modes, mouse events shouldn't affect selection or scrolling.
+    if matches!(self.mode, Mode::Help | Mode::ActionMenu | Mode::SignalMenu | Mode::Processing | Mode::Error) {
+      return vec![];
+    }
+
     let pos = Position::new(mouse.column, mouse.row);
 
     fn clamp_into(rect: Rect, pos: Position) -> Position {
@@ -1006,9 +1008,9 @@ impl Component for Home {
 
     match mouse.kind {
       MouseEventKind::Moved => {
-        let was_hovering = contains(self.file_path_rect, self.mouse_position);
+        let was_hovering = self.file_path_rect.contains(self.mouse_position);
         self.mouse_position = pos;
-        let is_hovering = contains(self.file_path_rect, pos);
+        let is_hovering = self.file_path_rect.contains(pos);
         if was_hovering != is_hovering {
           vec![Action::Render]
         } else {
@@ -1018,7 +1020,7 @@ impl Component for Home {
       MouseEventKind::ScrollUp => {
         self.mouse_position = pos;
         self.clear_logs_selection();
-        if contains(self.services_panel, pos) {
+        if self.services_panel.contains(pos) {
           if self.filtered_units.state.selected() == Some(0) {
             return vec![Action::EnterMode(Mode::Search)];
           }
@@ -1031,7 +1033,7 @@ impl Component for Home {
       MouseEventKind::ScrollDown => {
         self.mouse_position = pos;
         self.clear_logs_selection();
-        if contains(self.services_panel, pos) {
+        if self.services_panel.contains(pos) {
           self.next();
           vec![Action::Render]
         } else {
@@ -1040,7 +1042,7 @@ impl Component for Home {
       },
       MouseEventKind::Down(MouseButton::Left) => {
         self.mouse_position = pos;
-        if contains(self.file_path_rect, pos) {
+        if self.file_path_rect.contains(pos) {
           if let Some(m) = self.filtered_units.selected() {
             if let Some(Ok(path)) = &m.unit.file_path {
               crate::utils::copy_to_clipboard_osc52(path);
@@ -1049,7 +1051,27 @@ impl Component for Home {
             }
           }
         }
-        if contains(self.logs_panel_inner, pos) {
+        if self.search_panel.contains(pos) && self.mode == Mode::ServiceList {
+          return vec![Action::EnterMode(Mode::Search)];
+        }
+        if self.services_panel.contains(pos) && matches!(self.mode, Mode::ServiceList | Mode::Search) {
+          let inner = self.services_panel.inner(Margin::new(1, 1));
+          if inner.contains(pos) {
+            let clicked_index = self.filtered_units.state.offset() + (pos.y - inner.y) as usize;
+            if clicked_index < self.filtered_units.items.len() {
+              let was_search = self.mode == Mode::Search;
+              self.select(Some(clicked_index), true);
+              let mut actions = vec![];
+              if was_search {
+                actions.push(Action::EnterMode(Mode::ServiceList));
+              }
+              actions.push(Action::Render);
+              return actions;
+            }
+          }
+          return vec![];
+        }
+        if self.logs_panel_inner.contains(pos) {
           self.logs_selection = Some((pos, pos));
         } else {
           self.clear_logs_selection();
@@ -1309,6 +1331,8 @@ impl Component for Home {
     let main_panel = rects[1];
     let help_line_rect = rects[2];
 
+    self.search_panel = search_panel;
+
     // Helper for colouring based on the same logic as sysz
     // https://github.com/joehillen/sysz/blob/8da8e0dcbfde8d68fbdb22382671e395bd370d69/sysz#L69C1-L72C24
     //    Some units are colored based on state:
@@ -1459,7 +1483,7 @@ impl Component for Home {
 
       // Hover state is tested against the previous frame's rect; the rect itself is updated
       // below once the details layout is known.
-      let file_path_style = if contains(self.file_path_rect, self.mouse_position) {
+      let file_path_style = if self.file_path_rect.contains(self.mouse_position) {
         Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
       } else {
         Style::default()
@@ -1602,12 +1626,7 @@ impl Component for Home {
     f.render_widget(paragraph, logs_panel);
 
     // Inner area of the logs panel (border-excluded), used for mouse hit-testing and selection.
-    self.logs_panel_inner = Rect {
-      x: logs_panel.x.saturating_add(1),
-      y: logs_panel.y.saturating_add(1),
-      width: logs_panel.width.saturating_sub(2),
-      height: logs_panel.height.saturating_sub(2),
-    };
+    self.logs_panel_inner = logs_panel.inner(Margin::new(1, 1));
 
     if let Some((anchor, cursor)) = self.logs_selection {
       let inner = self.logs_panel_inner;

--- a/src/event.rs
+++ b/src/event.rs
@@ -61,6 +61,9 @@ impl EventHandler {
                   CrosstermEvent::Resize(x, y) => {
                     event_tx.send(Event::Resize(x, y)).unwrap();
                   },
+                  CrosstermEvent::Mouse(m) => {
+                    event_tx.send(Event::Mouse(m)).unwrap();
+                  },
                   _ => {},
                 }
               }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use crossterm::{
   cursor,
+  event::{DisableMouseCapture, EnableMouseCapture},
   terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::backend::CrosstermBackend as Backend;
@@ -40,7 +41,7 @@ impl Tui {
 
   pub fn enter(&self) -> Result<()> {
     crossterm::terminal::enable_raw_mode()?;
-    crossterm::execute!(std::io::stderr(), EnterAlternateScreen, cursor::Hide)?;
+    crossterm::execute!(std::io::stderr(), EnterAlternateScreen, cursor::Hide, EnableMouseCapture)?;
     Ok(())
   }
 
@@ -63,7 +64,7 @@ impl Tui {
 
 // This one's public because we want to expose it to the panic handler
 pub fn exit() -> Result<()> {
-  crossterm::execute!(std::io::stderr(), LeaveAlternateScreen, cursor::Show)?;
+  crossterm::execute!(std::io::stderr(), DisableMouseCapture, LeaveAlternateScreen, cursor::Show)?;
   crossterm::terminal::disable_raw_mode()?;
   Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -114,10 +114,60 @@ macro_rules! trace_dbg {
     };
 }
 
+/// Copy text to the system clipboard. Always emits OSC 52 (works over SSH and inside tmux), and
+/// additionally pipes the text to a system clipboard utility if one is available, for terminals
+/// that don't support OSC 52.
+pub fn copy_to_clipboard(text: &str) {
+  copy_to_clipboard_osc52(text);
+  copy_to_clipboard_native(text);
+}
+
+/// Best-effort copy via a system clipboard utility (wl-copy/xclip/xsel/pbcopy). These tools fork
+/// and keep serving the selection after we exit, which a write-and-drop native clipboard library
+/// can't do on X11/Wayland. Failures are silent by design; OSC 52 is the primary mechanism, and
+/// all output is redirected to null so nothing can scribble on the TUI.
+fn copy_to_clipboard_native(text: &str) {
+  use std::{
+    io::Write,
+    process::{Command, Stdio},
+  };
+
+  let candidates: &[&[&str]] = if cfg!(target_os = "macos") {
+    &[&["pbcopy"]]
+  } else if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+    &[&["wl-copy"], &["xclip", "-selection", "clipboard"], &["xsel", "--clipboard", "--input"]]
+  } else if std::env::var_os("DISPLAY").is_some() {
+    &[&["xclip", "-selection", "clipboard"], &["xsel", "--clipboard", "--input"]]
+  } else {
+    return; // no display server; OSC 52 is the only option (e.g. over SSH)
+  };
+
+  let text = text.to_owned();
+  let candidates: Vec<Vec<String>> = candidates.iter().map(|c| c.iter().map(|s| s.to_string()).collect()).collect();
+  // Write and reap in a background thread so a slow or missing utility can't stall the UI.
+  std::thread::spawn(move || {
+    for candidate in candidates {
+      let spawned = Command::new(&candidate[0])
+        .args(&candidate[1..])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+      if let Ok(mut child) = spawned {
+        if let Some(mut stdin) = child.stdin.take() {
+          let _ = stdin.write_all(text.as_bytes());
+        }
+        let _ = child.wait();
+        return;
+      }
+    }
+  });
+}
+
 /// Copy text to the system clipboard using an OSC 52 escape sequence, written directly to the
 /// TUI's output stream (stderr). This works over SSH and inside tmux (with `set-clipboard on`)
 /// without needing any special passthrough wrapping.
-pub fn copy_to_clipboard_osc52(text: &str) {
+fn copy_to_clipboard_osc52(text: &str) {
   use std::io::Write;
 
   use base64::{engine::general_purpose::STANDARD, Engine};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -114,6 +114,23 @@ macro_rules! trace_dbg {
     };
 }
 
+/// Copy text to the system clipboard using an OSC 52 escape sequence, written directly to the
+/// TUI's output stream (stderr). This works over SSH and inside tmux (with `set-clipboard on`)
+/// without needing any special passthrough wrapping.
+pub fn copy_to_clipboard_osc52(text: &str) {
+  use std::io::Write;
+
+  use base64::{engine::general_purpose::STANDARD, Engine};
+
+  let encoded = STANDARD.encode(text);
+  let mut stderr = std::io::stderr();
+  if let Err(e) = write!(stderr, "\x1b]52;c;{encoded}\x07") {
+    error!("Failed to write OSC 52 clipboard sequence: {e}");
+    return;
+  }
+  let _ = stderr.flush();
+}
+
 pub fn version() -> String {
   let author = clap::crate_authors!();
 

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -228,11 +228,23 @@ def test_mouse(binary: str, host: str | None) -> None:
     time.sleep(0.2)
     type_text("systemd-journald")
     time.sleep(0.3)
-    send_keys("Down")
-    time.sleep(0.5)
     send_keys("Escape")
     time.sleep(0.3)
-    check("selected systemd-journald.service for the remaining checks", "systemd-journald" in capture(), capture())
+    # Click the exact "systemd-journald" row rather than taking the first fuzzy match: the list
+    # also contains the systemd-journald@ template unit (empty description, no logs), and fuzzy
+    # ranking put it first on some distros, breaking every check below.
+    screen_lines = capture().splitlines()
+    exact_row = next((r for r in service_rows() if screen_lines[r][1:29].strip() == "systemd-journald"), None)
+    check("found the systemd-journald row", exact_row is not None, capture())
+    if exact_row is not None:
+        click(10, exact_row + 1)
+    # journald log lines always contain "systemd-journald[<pid>]:", so this also guarantees the
+    # unit under test has real logs for the wheel/drag checks below
+    check(
+        "selected systemd-journald.service for the remaining checks",
+        wait_for(lambda: "systemd-journald[" in capture()),
+        capture(),
+    )
 
     # 2. click on a details field copies the value and shows a toast
     desc_line = next((i for i, l in enumerate(capture().splitlines()) if "Description:" in l), None)
@@ -246,13 +258,26 @@ def test_mouse(binary: str, host: str | None) -> None:
         check("click on details field copies + shows toast", wait_for(lambda: re.search(r"Copied \d+ chars", capture()) is not None), capture())
         time.sleep(2.1)  # let the toast expire before the next assertion that checks for its absence
 
-    # 3. wheel scrolls logs
+    # 3. wheel scrolls logs. If the unit's logs fit entirely in the pane there is nothing to
+    # scroll (the offset is clamped to 0), so in that case assert that End can't scroll either
+    # instead of failing on unchanged content.
     logs_before = capture()
     for _ in range(3):
         send_mouse("wheel_down", 70, 20)
         time.sleep(0.3)
     logs_after = capture()
-    check("wheel scrolls logs", logs_after != logs_before, f"before:\n{logs_before}\nafter:\n{logs_after}")
+    if logs_after != logs_before:
+        check("wheel scrolls logs", True)
+    else:
+        send_keys("End")
+        time.sleep(0.5)
+        check(
+            "wheel scrolls logs (logs fit on screen; End can't scroll either)",
+            capture() == logs_before,
+            f"wheel did nothing but End scrolled:\n{capture()}",
+        )
+        send_keys("Home")
+        time.sleep(0.3)
 
     # 4. drag-selecting log text copies it and shows a toast
     send_mouse("press", 40, 11)

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -260,12 +260,18 @@ def test_mouse(binary: str, host: str | None) -> None:
 
     # 3. wheel scrolls logs. If the unit's logs fit entirely in the pane there is nothing to
     # scroll (the offset is clamped to 0), so in that case assert that End can't scroll either
-    # instead of failing on unchanged content.
-    logs_before = capture()
+    # instead of failing on unchanged content. Compare only the logs pane: the details pane
+    # contains relative timestamps ("(17s ago)") that tick between captures.
+    def logs_region() -> str:
+        lines = capture().splitlines()
+        start = next((i for i, l in enumerate(lines) if "Service Logs" in l), 0)
+        return "\n".join(lines[start:])
+
+    logs_before = logs_region()
     for _ in range(3):
         send_mouse("wheel_down", 70, 20)
         time.sleep(0.3)
-    logs_after = capture()
+    logs_after = logs_region()
     if logs_after != logs_before:
         check("wheel scrolls logs", True)
     else:
@@ -273,7 +279,7 @@ def test_mouse(binary: str, host: str | None) -> None:
         time.sleep(0.5)
         check(
             "wheel scrolls logs (logs fit on screen; End can't scroll either)",
-            capture() == logs_before,
+            logs_region() == logs_before,
             f"wheel did nothing but End scrolled:\n{capture()}",
         )
         send_keys("Home")

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -243,7 +243,7 @@ def test_mouse(binary: str, host: str | None) -> None:
         match = re.search(r"\S", line[idx:])
         value_col = idx + match.start() + 3 if match else idx + 3
         click(value_col, desc_line + 1)
-        check("click on details field copies + shows toast", wait_for(lambda: "via OSC 52" in capture()), capture())
+        check("click on details field copies + shows toast", wait_for(lambda: re.search(r"Copied \d+ chars", capture()) is not None), capture())
         time.sleep(2.1)  # let the toast expire before the next assertion that checks for its absence
 
     # 3. wheel scrolls logs
@@ -262,7 +262,7 @@ def test_mouse(binary: str, host: str | None) -> None:
     send_mouse("drag", 48, 11)
     time.sleep(0.1)
     send_mouse("release", 48, 11)
-    check("drag selection copies log text", wait_for(lambda: "via OSC 52" in capture()), capture())
+    check("drag selection copies log text", wait_for(lambda: re.search(r"Copied \d+ chars", capture()) is not None), capture())
     time.sleep(2.1)
 
     # 5. clicking outside the action menu closes it

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -44,11 +44,35 @@ def capture() -> str:
     return tmux("capture-pane", "-t", SESSION, "-p").stdout
 
 
+def capture_esc() -> str:
+    """Like capture(), but keeps ANSI escape sequences (e.g. to detect highlight colors)."""
+    return tmux("capture-pane", "-t", SESSION, "-e", "-p").stdout
+
+
 def send_keys(*keys: str, delay: float = 0.0) -> None:
     for key in keys:
         tmux("send-keys", "-t", SESSION, key)
         if delay:
             time.sleep(delay)
+
+
+def send_mouse(kind: str, col: int, row: int) -> None:
+    """Inject an SGR mouse event (1-based col/row) - the app enables SGR mouse tracking
+    (crossterm's EnableMouseCapture), so tmux can feed it raw escape sequences as if a real
+    mouse driver produced them.
+
+    kind: press|release|drag|move|wheel_up|wheel_down
+    """
+    code = {"press": "0", "release": "0", "drag": "32", "move": "35", "wheel_up": "64", "wheel_down": "65"}[kind]
+    suffix = "m" if kind == "release" else "M"
+    tmux("send-keys", "-t", SESSION, "-l", f"\x1b[<{code};{col};{row}{suffix}")
+
+
+def click(col: int, row: int) -> None:
+    """Press + release the left mouse button at a 1-based (col, row)."""
+    send_mouse("press", col, row)
+    time.sleep(0.1)
+    send_mouse("release", col, row)
 
 
 def start_app(binary: str, host: str | None, extra_args: list[str] | None = None) -> None:
@@ -146,6 +170,129 @@ def test_logs(binary: str, host: str | None) -> None:
 
     check("logs pane shows logs or diagnostic", wait_for(logs_or_diagnostic), capture())
     check("app still alive", app_alive())
+
+
+def test_mouse(binary: str, host: str | None) -> None:
+    """Mouse handling is client-side (crossterm SGR parsing + ratatui rect hit-testing), so this
+    runs identically in local and remote mode - unlike most of the remote suite it isn't testing
+    anything ssh-specific.
+    """
+    print("mouse interactions:")
+    start_app(binary, host)
+    wait_for(lambda: "Services" in capture())
+    # initial mode is Search; leave it so plain keys like 'f' below aren't typed into the box
+    send_keys("Escape")
+    time.sleep(0.3)
+
+    def highlighted_row(screen_esc: str) -> int | None:
+        """Row (0-based, matching capture().splitlines()) carrying the list-selection background."""
+        for i, line in enumerate(screen_esc.splitlines()):
+            if "48;5;8" in line:
+                return i
+        return None
+
+    def service_rows() -> list[int]:
+        """0-based row indices of visible, non-empty service list entries (left ~29 cols)."""
+        rows = []
+        lines = capture().splitlines()
+        in_list = False
+        for i, line in enumerate(lines):
+            if "Services" in line[:30]:
+                in_list = True
+                continue
+            if not in_list:
+                continue
+            if line.lstrip().startswith("╰"):
+                break
+            name = line[1:29].strip()
+            if name:
+                rows.append(i)
+        return rows
+
+    # 1. click selects a service
+    rows = service_rows()
+    before = highlighted_row(capture_esc())
+    target = next((r for r in rows if r != before), rows[0] if rows else None)
+    check("found a clickable service row", target is not None)
+    if target is not None:
+        click(10, target + 1)
+        time.sleep(0.4)
+        after = highlighted_row(capture_esc())
+        check("click selects a service", after == target, f"before={before} target={target} after={after}")
+
+    # For the rest of this test we want a unit with a guaranteed non-empty description and
+    # plenty of log history to scroll/select, so the click/wheel/drag checks below aren't at the
+    # mercy of whichever unit happened to be under the cursor in step 1. systemd-journald.service
+    # is a real (non-alias) unit that has logged on any systemd machine (see test_logs).
+    send_keys("C-f")
+    time.sleep(0.2)
+    type_text("systemd-journald")
+    time.sleep(0.3)
+    send_keys("Down")
+    time.sleep(0.5)
+    send_keys("Escape")
+    time.sleep(0.3)
+    check("selected systemd-journald.service for the remaining checks", "systemd-journald" in capture(), capture())
+
+    # 2. click on a details field copies the value and shows a toast
+    desc_line = next((i for i, l in enumerate(capture().splitlines()) if "Description:" in l), None)
+    check("details pane shows a Description field", desc_line is not None, capture())
+    if desc_line is not None:
+        line = capture().splitlines()[desc_line]
+        idx = line.index("Description:") + len("Description:")
+        match = re.search(r"\S", line[idx:])
+        value_col = idx + match.start() + 3 if match else idx + 3
+        click(value_col, desc_line + 1)
+        check("click on details field copies + shows toast", wait_for(lambda: "via OSC 52" in capture()), capture())
+        time.sleep(2.1)  # let the toast expire before the next assertion that checks for its absence
+
+    # 3. wheel scrolls logs
+    logs_before = capture()
+    for _ in range(3):
+        send_mouse("wheel_down", 70, 20)
+        time.sleep(0.3)
+    logs_after = capture()
+    check("wheel scrolls logs", logs_after != logs_before, f"before:\n{logs_before}\nafter:\n{logs_after}")
+
+    # 4. drag-selecting log text copies it and shows a toast
+    send_mouse("press", 40, 11)
+    time.sleep(0.1)
+    send_mouse("drag", 44, 11)
+    time.sleep(0.1)
+    send_mouse("drag", 48, 11)
+    time.sleep(0.1)
+    send_mouse("release", 48, 11)
+    check("drag selection copies log text", wait_for(lambda: "via OSC 52" in capture()), capture())
+    time.sleep(2.1)
+
+    # 5. clicking outside the action menu closes it
+    send_keys("Enter")
+    check("action menu opens", wait_for(lambda: "Actions for" in capture()), capture())
+    click(5, 5)
+    time.sleep(0.4)
+    check("click outside closes action menu", "Actions for" not in capture(), capture())
+    check("app alive after closing menu", app_alive())
+
+    # 6. clicking a status filter entry toggles it
+    send_keys("Escape")
+    time.sleep(0.3)
+    send_keys("f")
+    check("status filter popup opens", wait_for(lambda: "Status filter" in capture()), capture())
+    filter_line = next((i for i, l in enumerate(capture().splitlines()) if "✓ active" in l), None)
+    check("status filter has a checked entry", filter_line is not None, capture())
+    if filter_line is not None:
+        line = capture().splitlines()[filter_line]
+        col = line.index("✓ active") + 2  # land inside "active", not on the border/checkmark
+        click(col, filter_line + 1)
+        time.sleep(0.4)
+        toggled = capture().splitlines()[filter_line]
+        check("clicking a status filter entry toggles its checkmark", "✓ active" not in toggled, toggled)
+    click(5, 5)
+    time.sleep(0.4)
+    check("click outside closes status filter popup", "Status filter" not in capture(), capture())
+
+    check("app alive after mouse interactions", app_alive())
+    send_keys("q")
 
 
 def test_no_dropped_keystrokes(binary: str, host: str | None) -> None:
@@ -379,6 +526,7 @@ def main() -> int:
     try:
         test_startup_and_browse(args.binary, args.host)
         test_logs(args.binary, args.host)
+        test_mouse(args.binary, args.host)
         if not args.remote_suite:
             test_no_dropped_keystrokes(args.binary, args.host)
         test_clean_exit(args.binary, args.host)


### PR DESCRIPTION
systemctl-tui has always been keyboard-only. After seeing how nicely tools like Claude Code handle the mouse in the terminal, I wanted the same here: click things, select text, copy it. This PR adds mouse support across the whole app.

## Details

1. Drag in the logs pane to select text (highlighted as you drag) and copy it on release. Selection reads straight out of the render buffer, so it only covers visible text — same as native terminal selection.
2. Every field in the details pane (description, states, unit file path, runtime stats) goes bold on hover and copies its full text on click. Handy for grabbing unit file paths.
3. Clicking works everywhere else you'd expect: services list rows, the search bar, status filter entries, action/signal menu items. Clicking outside a popup closes it; clicking the help or error popup dismisses it.
4. The scroll wheel scrolls the logs, moves the service selection over the list, and moves the cursor in popups.
5. A small "Copied N chars" toast shows in the bottom right after any copy.
6. Copying emits OSC 52 (works over SSH and in tmux) and also pipes to `wl-copy`/`xclip`/`xsel`/`pbcopy` when available, for terminals without OSC 52 support.

While I was in the area I fixed the long-standing scroll-to-bottom TODO: the logs scroll offset is now clamped to the real wrapped height via ratatui's `unstable-rendered-line-info` feature, so `End` and `PageDown` can no longer scroll past the end into blank space.

## Trade-offs

Enabling mouse capture means the terminal's native drag-to-select no longer works inside the app; the in-app selection replaces it for logs, and most terminals still offer shift+drag as an escape hatch. There is also no built-in mouse support in ratatui (it's render-only by design), so the hit-testing is hand-rolled: widgets record their rects at render time and the mouse handler tests against them.

This also replaces the `clipboard-anywhere` dependency. Its write-and-drop native clipboard call could not reliably serve pastes on X11/Wayland (the process has to stay alive), and its warning about exactly that printed over the TUI. The clipboard utilities we shell out to fork and keep serving the selection themselves.

## Testing

The integration tests now inject raw SGR mouse escape sequences through tmux and cover click-to-select, click-to-copy (asserted via the toast), wheel scrolling, drag selection, and popup click behaviour. 27 checks pass locally, and I verified the native clipboard path end-to-end with `wl-paste` on Wayland.
