### PR TITLE
Explain common systemd units

### DIFF
--- a/scripts/harvest-units.py
+++ b/scripts/harvest-units.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []
+# ///
+"""Harvest candidate unit names for the baked-in descriptions database.
+
+Collects unit names from the local machine (system + user scope), collapses
+templated instances down to their template, and filters out machine-specific
+or auto-generated noise. Prints the surviving candidates with the systemd
+Description= for reference, plus a rejects list so we can sanity-check the
+filters.
+"""
+
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# Unit types that are inherently machine-specific or auto-generated.
+# devices/mounts/swaps/scopes/slices come from hardware or the fstab/cgroup
+# layout; there's nothing useful to pre-describe.
+SKIP_SUFFIXES = (".device", ".swap", ".scope", ".snapshot")
+
+# Mounts are mostly machine-specific, but a handful of API-filesystem mounts
+# are universal and genuinely confusing ("what is proc-sys-fs-binfmt_misc?").
+KEEP_MOUNTS = {
+    "proc-sys-fs-binfmt_misc.mount",
+    "sys-fs-fuse-connections.mount",
+    "sys-kernel-config.mount",
+    "sys-kernel-debug.mount",
+    "sys-kernel-tracing.mount",
+    "dev-hugepages.mount",
+    "dev-mqueue.mount",
+    "tmp.mount",
+    "boot.mount",
+    "run-user-1000.mount",  # placeholder; template-collapsed below
+}
+
+# Patterns that mark a unit as machine/instance-specific even after
+# template collapsing.
+NOISE_PATTERNS = [
+    re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}"),  # UUIDs
+    re.compile(r"[0-9a-f]{32}"),  # long hex ids
+    re.compile(r"\\x[0-9a-f]{2}"),  # escaped paths (dev-disk-by\x2d...)
+    re.compile(r"^(dev|sys|proc|run|home|media|mnt|var|srv|snap)-.*\.mount$"),
+    re.compile(r"^dbus-:"),  # dbus-activated transient names
+    re.compile(r"^dbus-org\."),  # alias units for the real service
+    re.compile(r"^app-"),  # per-app desktop launcher wrappers
+    re.compile(r"^snap\."),  # per-snap-app units (snapd.* itself is kept)
+]
+
+# Units specific to this machine's owner or to systemctl-tui development.
+LOCAL_ONLY = {
+    "handy-ptt.service",
+    "reitunes.service",
+    "reitunez.service",
+    "systemctl-tui-polkit-test.service",
+    "test-dummy.service",
+    "ttyd.service",
+}
+
+
+def list_units(scope_args: list[str]) -> dict[str, str]:
+    """Return {unit_name: description} from list-units + list-unit-files."""
+    units: dict[str, str] = {}
+    out = subprocess.run(
+        ["systemctl", *scope_args, "list-units", "--all", "--no-legend", "--plain", "--full"],
+        capture_output=True, text=True,
+    ).stdout
+    for line in out.splitlines():
+        parts = line.split(None, 4)
+        if len(parts) >= 5:
+            units[parts[0]] = parts[4]
+        elif parts:
+            units[parts[0]] = ""
+    out = subprocess.run(
+        ["systemctl", *scope_args, "list-unit-files", "--no-legend", "--plain", "--full"],
+        capture_output=True, text=True,
+    ).stdout
+    for line in out.splitlines():
+        parts = line.split()
+        if parts:
+            units.setdefault(parts[0], "")
+    return units
+
+
+def collapse_template(name: str) -> str:
+    """getty@tty1.service -> getty@.service"""
+    m = re.match(r"^([^@]+)@(.+)(\.[a-z]+)$", name)
+    if m:
+        return f"{m.group(1)}@{m.group(3)}"
+    return name
+
+
+def wanted(name: str) -> bool:
+    if name.endswith(SKIP_SUFFIXES):
+        return False
+    if name.endswith(".mount") and name not in KEEP_MOUNTS:
+        return False
+    if name in LOCAL_ONLY:
+        return False
+    return not any(p.search(name) for p in NOISE_PATTERNS)
+
+
+def main() -> None:
+    scopes = [("system", ["--system"]), ("user", ["--user"])]
+    kept: dict[str, str] = {}
+    rejected: set[str] = set()
+    per_scope_counts: dict[str, int] = defaultdict(int)
+
+    for scope_name, args in scopes:
+        for name, desc in list_units(args).items():
+            per_scope_counts[scope_name] += 1
+            collapsed = collapse_template(name)
+            if wanted(collapsed):
+                # Prefer a non-empty description; template desc may vary per
+                # instance, first one wins which is fine for reference.
+                if collapsed not in kept or (not kept[collapsed] and desc):
+                    kept[collapsed] = desc
+            else:
+                rejected.add(collapsed)
+
+    print(f"# Harvested from local machine: "
+          f"{per_scope_counts['system']} system + {per_scope_counts['user']} user units")
+    print(f"# Kept {len(kept)} candidates, rejected {len(rejected)} as noise\n")
+    for name in sorted(kept):
+        desc = kept[name]
+        print(f"{name}\t{desc}" if desc else name)
+
+    if "--show-rejects" in sys.argv:
+        print("\n# Rejected:")
+        for name in sorted(rejected):
+            print(name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/harvest-units.py
+++ b/scripts/harvest-units.py
@@ -57,7 +57,6 @@ LOCAL_ONLY = {
     "reitunez.service",
     "systemctl-tui-polkit-test.service",
     "test-dummy.service",
-    "ttyd.service",
 }
 
 

--- a/src/assets/unit-descriptions.tsv
+++ b/src/assets/unit-descriptions.tsv
@@ -1,0 +1,455 @@
+# Baked-in plain-English explanations of common systemd units.
+# Format: unit-name<TAB>scope<TAB>description. Scope is system, user, or both.
+# Templated units use the template name (foo@.service).
+# Generated with LLM assistance; regenerate/extend via scripts/harvest-units.py.
+-.slice	both	The root of systemd's control-group hierarchy. Every process managed by systemd belongs to this slice or one beneath it.
+ModemManager.service	system	Manages mobile-broadband modems and provides a D-Bus API for configuring cellular connections. Network managers use it to discover modems, unlock SIMs, and establish data connections.
+NetworkManager-dispatcher.service	system	Runs dispatcher scripts when NetworkManager reports events such as an interface connecting or disconnecting. Administrators and packages use these hooks to react to network state changes.
+NetworkManager-wait-online.service	system	Waits until NetworkManager reports that startup networking is complete, then allows units ordered after `network-online.target` to proceed. It delays those units when required connections are still activating.
+NetworkManager.service	system	Manages Ethernet, Wi-Fi, mobile-broadband, and VPN connections. Desktop settings, `nmcli`, and other clients control connections through its D-Bus API.
+accounts-daemon.service	system	Provides user-account information such as names, avatars, and login history through the AccountsService D-Bus API. Login screens and settings panels use it to display and manage local users.
+acpid.service	system	Handles ACPI events from the kernel, such as power-button presses and laptop-lid changes. It runs actions configured for matching hardware events.
+acpid.socket	system	Accepts ACPI event connections and activates `acpid.service` when they arrive.
+alsa-restore.service	system	Restores saved ALSA sound-card mixer settings during boot. This preserves volume, mute, and other hardware controls across restarts.
+alsa-state.service	system	Runs the ALSA state daemon to save and restore sound-card mixer settings as hardware appears and disappears. It preserves controls such as volume and mute across restarts.
+anacron.service	system	Runs periodic jobs that became due while the computer was powered off. It reads the system anacrontab and records completion timestamps to avoid running a job more often than configured.
+anacron.timer	system	Checks periodically for overdue jobs and starts `anacron.service`.
+apache2.service	system	Runs the Apache HTTP server under its Debian and Ubuntu unit name. It serves configured websites and can proxy requests to application servers.
+app.slice	user	Groups a user's application processes so systemd can account for and manage their resources separately. Desktop session managers commonly place launched applications beneath this slice.
+apparmor.service	system	Loads AppArmor security profiles that restrict which files, capabilities, and other resources programs may access. It prepares the kernel policy used to confine profiled processes.
+apport-autoreport.path	system	Watches for pending Ubuntu crash reports and starts `apport-autoreport.service` when they appear. This lets reports be processed as soon as they are written to the crash directory.
+apport-autoreport.service	system	Processes pending Ubuntu crash reports through Apport's automatic reporting workflow. It reads reports collected after crashes and submits eligible diagnostic data to Ubuntu's error tracker.
+apport-autoreport.timer	system	Periodically starts automatic processing of pending Ubuntu crash reports.
+apport.service	system	Collects diagnostic information when a program crashes and prepares an Ubuntu crash report. The report combines the crash data with package, process, and system details used for diagnosis.
+apt-daily-upgrade.service	system	Installs available updates and performs package cleanup through APT's unattended-upgrade machinery. It is normally started by `apt-daily-upgrade.timer` and uses the same APT configuration as manually initiated upgrades.
+apt-daily-upgrade.timer	system	Schedules the daily APT unattended-upgrade and cleanup job.
+apt-daily.service	system	Refreshes APT package metadata and downloads package updates in the background. It is normally started by `apt-daily.timer`, making current repository information available to other package-management tools.
+apt-daily.timer	system	Schedules the daily APT package download job.
+at-spi-dbus-bus.service	user	Provides the D-Bus accessibility bus used by assistive technologies and desktop applications. Screen readers and other accessibility tools use it to inspect and interact with application interfaces.
+atd.service	system	Runs jobs queued by the `at` and `batch` commands at their requested times. Unlike cron jobs, these are one-time commands stored in the system's `at` queue.
+auditd.service	system	Receives Linux Audit events from the kernel and writes them to the audit log. Audit rules determine which security-relevant system calls, file accesses, and account events it records.
+auth-rpcgss-module.service	system	Loads the kernel module used for Kerberos-authenticated NFS and other RPCSEC_GSS traffic. NFS setup orders this unit before services that require GSS-authenticated RPC.
+autovt@.service	system	Starts a text login prompt on a virtual terminal when that terminal is first accessed. Each instance is tied to a console such as `tty2` and launches a getty there.
+avahi-daemon.service	system	Implements multicast DNS and DNS service discovery on the local network. Applications use it to advertise and find devices and services such as printers without conventional DNS configuration.
+avahi-daemon.socket	system	Receives local Avahi client connections and activates the Avahi daemon on demand.
+background.slice	user	Groups low-priority background services in a user's systemd manager for resource management. Desktop components can place non-interactive work here so it receives different scheduling and memory policy from foreground applications.
+basic.target	both	Marks the point in startup when basic services, sockets, paths, and timers are available.
+binfmt-support.service	system	Registers handlers that let the kernel launch additional executable formats through `binfmt_misc`. Configured interpreters can then handle files such as foreign binaries or bytecode when they are executed directly.
+blockdev@.target	system	Provides an ordering point for preparation of the block device named by the unit instance.
+bluetooth.service	system	Runs the BlueZ daemon, which manages Bluetooth adapters, pairing, devices, and connections. Desktop settings and applications control Bluetooth through its D-Bus interfaces.
+bluetooth.target	both	Groups units needed to provide Bluetooth support.
+bolt.service	system	Manages authorization and enrollment of Thunderbolt devices such as docks and external GPUs. Desktop settings use its D-Bus API to approve devices on systems with Thunderbolt security enabled.
+boot-complete.target	system	Marks a boot as successfully completed after any configured boot-health checks have passed.
+chrony-wait.service	system	Waits for chronyd to synchronize the system clock before allowing time-dependent units to proceed. Units that require an accurate clock can order themselves after it.
+chrony.service	system	Runs chronyd to synchronize the system clock with NTP servers. Chronyd continuously estimates clock drift and corrects the local time while the machine is running.
+chronyd.service	system	Runs chronyd to synchronize the system clock with NTP servers and, when configured, provide time to other machines. It continuously estimates clock drift and corrects the local time.
+cloud-config.service	system	Runs cloud-init's configuration stage after networking is available. Its modules handle settings such as locale, package sources, and SSH configuration supplied by the cloud data source.
+cloud-config.target	system	Marks cloud-init's configuration stage as available to dependent units.
+cloud-final.service	system	Runs cloud-init's final modules after networking and most system services are available. These include package installation, configuration-management integrations, and user-provided startup scripts.
+cloud-init-local.service	system	Runs cloud-init's early local stage before networking is configured. It discovers the instance data source and can apply network configuration needed for later stages.
+cloud-init.service	system	Runs cloud-init modules that require configured networking and consume network-provided instance metadata. It applies the instance's main initialization configuration before the final cloud-init stage.
+cloud-init.target	system	Groups the cloud-init stages so other units can order themselves after instance initialization.
+colord-session.service	user	Provides color-management services to applications in a desktop user session. It connects session applications with colord's device profiles and color transformations.
+colord.service	system	Stores color profiles and associates them with displays, printers, scanners, and cameras. Desktop applications use its D-Bus API to apply consistent color calibration across devices.
+configure-printer@.service	system	Configures a newly discovered printer for use through CUPS. Each instance creates or updates the local queue for one detected printer.
+connman.service	system	Manages wired, Wi-Fi, and mobile network connections through the ConnMan daemon. Clients configure and monitor connections through its D-Bus API.
+console-getty.service	system	Provides a text login prompt on a container or system console. It attaches a getty to `/dev/console` when that console is suitable for interactive login.
+console-setup.service	system	Applies the configured keyboard layout and font to Linux virtual consoles. This determines how keys and characters behave outside the graphical desktop.
+container-getty@.service	system	Provides a text login prompt on an additional terminal exposed by a container manager. Each instance attaches a getty to one container pseudo-terminal.
+containerd.service	system	Runs the containerd runtime, which manages container images, storage, lifecycle, and low-level runtimes. Higher-level tools such as Docker and Kubernetes ask it to create containers, manage snapshots, and invoke an OCI runtime such as `runc`.
+cron.service	system	Runs commands at scheduled times from system and user crontabs. It wakes at the configured minute, hour, day, and month fields and launches matching jobs.
+crond.service	system	Runs commands at scheduled times from system and user crontabs under Fedora and RHEL-family distributions. It wakes at the configured time fields and launches matching jobs.
+cryptsetup-pre.target	system	Provides an ordering point before local encrypted volumes are unlocked.
+cryptsetup.target	system	Groups local encrypted block devices that must be unlocked during startup.
+ctrl-alt-del.target	system	Handles a Ctrl+Alt+Delete request, normally by starting a system reboot. Systemd activates this target when it receives the corresponding key sequence or signal.
+cups-browsed.service	system	Discovers shared and driverless IPP printers on the network. It creates and removes local CUPS queues as advertised printers appear and disappear.
+cups.path	system	Watches CUPS's scheduler state file and starts `cups.service` when that file exists. This lets saved scheduler state reactivate the print service through systemd path activation.
+cups.service	system	Runs the CUPS print server, managing print queues and communicating with local and network printers. Applications submit jobs and query printer status through its IPP interface.
+cups.socket	system	Listens for CUPS client connections and activates the print scheduler on demand.
+dbus-broker.service	both	Runs the D-Bus message broker used by services and applications in the corresponding system or user manager. It routes method calls, replies, and signals between processes and starts D-Bus-activated services when first requested.
+dbus-broker.socket	both	Listens for D-Bus connections and activates `dbus-broker.service` in the corresponding system or user manager.
+dbus.service	both	Runs the D-Bus message bus used by services and applications in the corresponding system or user manager. It routes method calls, replies, and signals between processes and starts D-Bus-activated services when first requested.
+dbus.socket	both	Listens for D-Bus connections and activates the configured message-bus service in the corresponding system or user manager.
+dconf.service	user	Provides the dconf settings database used by GNOME and other desktop applications. Applications access shared preferences through this service and are notified when settings change.
+debug-shell.service	system	Starts a root shell on a dedicated virtual terminal for early-boot debugging. Systemd places the unauthenticated shell on the configured debug TTY so startup problems can be inspected directly.
+default.target	both	Names the default collection of units started by a system or user systemd manager.
+dirmngr.service	user	Handles certificate revocation checks and retrieves keys and certificates from network servers for GnuPG. GnuPG clients use it for keyserver, LDAP, OCSP, and certificate revocation list access.
+dirmngr.socket	user	Accepts GnuPG network-helper requests and activates `dirmngr.service`.
+display-manager.service	system	Starts the configured graphical login manager, such as GDM, SDDM, or LightDM. The manager presents the login screen and launches the selected desktop session after authentication.
+dnf-makecache.service	system	Refreshes cached package and repository metadata used by DNF. Its timer starts it periodically so package searches and update checks can use current repository information.
+dnf-makecache.timer	system	Schedules periodic refreshes of DNF package and repository metadata.
+docker.service	system	Runs the Docker daemon, which builds images and creates and manages containers. The Docker CLI and API clients send it requests over its Unix socket or configured network endpoints.
+docker.socket	system	Listens for Docker API requests and activates the Docker daemon on demand.
+dpkg-db-backup.service	system	Creates a backup of the Debian package database. Its timer runs it periodically so package status and metadata can be recovered after database corruption.
+dpkg-db-backup.timer	system	Schedules regular backups of the Debian package database.
+e2scrub@.service	system	Checks an ext-family filesystem's metadata while it remains mounted, using an LVM snapshot when required. Each instance examines one filesystem and reports problems without modifying the live filesystem.
+e2scrub_all.service	system	Starts online metadata checks for all eligible ext-family filesystems. It discovers suitable mounts and invokes the per-filesystem scrub operation for each one.
+e2scrub_all.timer	system	Periodically schedules online metadata checks for eligible ext-family filesystems.
+e2scrub_fail@.service	system	Reports a failed ext4 online metadata check for the filesystem named by the unit instance. It records the scrub failure so an administrator can investigate and perform an offline repair if needed.
+e2scrub_reap.service	system	Removes stale LVM snapshots left by interrupted ext4 online metadata checks. This reclaims snapshot storage after a scrub fails or is terminated before cleanup.
+emergency.service	system	Starts the minimal emergency shell used to repair a system when normal startup cannot continue. It runs with very few filesystems or supporting services available.
+emergency.target	system	Provides the most minimal recovery environment, with an emergency shell and few other services.
+evolution-addressbook-factory.service	user	Provides contacts and address books to Evolution and other applications using Evolution Data Server. It creates backend processes for local and remote address-book sources requested by clients.
+evolution-calendar-factory.service	user	Provides calendars, tasks, and memos to Evolution and other applications using Evolution Data Server. It creates backend processes for configured local and remote calendar sources.
+evolution-source-registry.service	user	Tracks the accounts and data sources used by Evolution Data Server for mail, calendars, and contacts. Other Evolution Data Server components query it to find each source and its configuration.
+exit.target	both	Stops a user systemd manager or container when reached.
+filter-chain.service	user	Runs PipeWire's filter-chain daemon for configured audio-processing filters. It creates audio nodes from filter graphs such as equalizers, mixers, and channel converters.
+final.target	system	Provides a late shutdown ordering point for services that must run immediately before systemd exits.
+firewalld.service	system	Manages firewall rules and network zones dynamically through nftables or iptables backends. Network managers and administration tools use its D-Bus API to adjust rules without rebuilding the entire firewall.
+first-boot-complete.target	system	Marks completion of first-boot provisioning and machine initialization.
+flatpak-portal.service	user	Mediates Flatpak requests to desktop portals and manages access to portal interfaces. Sandboxed applications reach desktop capabilities such as file choosers and notifications through this service.
+flatpak-session-helper.service	user	Provides Flatpak session services such as application monitoring and permission integration. It tracks sandboxed applications in the desktop session and connects them with Flatpak's permission machinery.
+flatpak-system-helper.service	system	Performs privileged Flatpak installation and repository operations requested by unprivileged clients. The user-facing Flatpak process calls it over D-Bus when changing system-wide installations.
+fprintd.service	system	Provides fingerprint-reader enrollment and verification through a D-Bus API. Login managers, authentication modules, and desktop settings use it to work with supported readers.
+fstrim.service	system	Sends discard requests for unused blocks on mounted filesystems listed for periodic trimming. This informs supporting SSDs and thin-provisioned storage which blocks no longer contain live data.
+fstrim.timer	system	Schedules a periodic trim of unused filesystem blocks on supporting storage devices.
+fwupd-refresh.service	system	Downloads current firmware metadata from configured fwupd remotes and refreshes the available-update cache. Desktop software centers and `fwupdmgr` use that cache when showing firmware updates.
+fwupd-refresh.timer	system	Schedules periodic refreshes of firmware metadata.
+fwupd.service	system	Detects supported hardware and stages or installs firmware updates supplied through LVFS and other configured remotes. Desktop software centers and `fwupdmgr` communicate with it over D-Bus to inspect devices and apply updates.
+gcr-ssh-agent.service	user	Provides an SSH agent backed by GCR so desktop keyring credentials can be used for SSH authentication. SSH clients contact it through the agent socket when they need a key to sign an authentication request.
+gcr-ssh-agent.socket	user	Listens for SSH-agent clients and activates the GCR-backed SSH agent. The socket path can be used as `SSH_AUTH_SOCK` by programs in the desktop session.
+gdm.service	system	Runs the GNOME Display Manager, which presents the graphical login screen and starts desktop sessions. It authenticates users and launches the selected GNOME or other installed session.
+gdm3.service	system	Runs the Debian and Ubuntu packaging of GNOME Display Manager for graphical logins and desktop sessions. It authenticates users and launches the desktop session selected at the login screen.
+geoclue.service	system	Provides applications with location estimates from configured network and hardware location sources. Desktop applications request location data through its D-Bus API, subject to the configured access policy.
+getty-pre.target	system	Provides an ordering point before text login prompts are started.
+getty-static.service	system	Starts fallback text login prompts on tty2 through tty6 when D-Bus and systemd-logind are unavailable.
+getty.target	system	Groups the system's local text login prompts.
+getty@.service	system	Provides a text login prompt on a Linux virtual console, with one instance for each console. It runs `agetty`, which reads the login name and hands authentication to the system login program.
+gnome-initial-setup-first-login.service	user	Runs GNOME's first-login setup assistant for an existing user account. It guides the user through initial desktop settings such as language, privacy, and online accounts.
+gnome-keyring-daemon.service	user	Stores passwords, keys, and other secrets for a GNOME user session and performs cryptographic operations with them. Applications use its Secret Service and related interfaces to retrieve credentials without storing them directly.
+gnome-keyring-daemon.socket	user	Accepts requests for GNOME Keyring and activates its daemon in the user session. Clients use this socket to reach the keyring's secret-storage and cryptographic services.
+gnome-remote-desktop-headless.service	user	Runs GNOME Remote Desktop without a local graphical session, providing remote access to a headless desktop. It creates a desktop that can be reached remotely rather than sharing a session already visible on a monitor.
+gnome-remote-desktop.service	both	Provides GNOME screen sharing, remote control, or remote login using RDP or VNC. GNOME's sharing settings configure it, and remote clients connect to the enabled protocol endpoint.
+gnome-session-manager@.service	user	Runs the GNOME session manager for a named session, starting and monitoring its desktop components. It coordinates session startup, tracks required processes, and shuts the session down when the user logs out.
+gnome-session-pre.target	user	Groups tasks that must finish before a GNOME graphical session starts.
+gnome-session-shutdown.target	user	Coordinates the shutdown of services belonging to a GNOME session.
+gnome-session-wayland.target	user	Groups the components of the current GNOME Wayland session.
+gnome-session-x11.target	user	Groups the components of the current GNOME X11 session.
+gnome-session.target	user	Groups services belonging to the current GNOME desktop session.
+gnome-session@.target	user	Groups the components of a named GNOME desktop session.
+gnome-terminal-server.service	user	Runs the per-user server process that creates and manages GNOME Terminal windows. New terminal invocations ask this shared process to create windows, tabs, and their child shells.
+gpg-agent-browser.socket	user	Accepts GnuPG agent requests from web browsers through the agent's browser protocol. It gives browser integrations a deliberately limited route to supported cryptographic operations.
+gpg-agent-extra.socket	user	Provides a restricted secondary socket for forwarding GnuPG agent operations into another environment. It is commonly forwarded into containers or remote sessions that need access to keys held on the host.
+gpg-agent-ssh.socket	user	Provides GnuPG's SSH-agent-compatible socket for SSH authentication with managed keys. SSH clients can use it as `SSH_AUTH_SOCK` to sign authentication requests with keys known to GnuPG.
+gpg-agent.service	user	Manages GnuPG private-key operations and caches passphrases for the user session. GnuPG tools delegate signing, decryption, and smart-card access to this process so secret keys remain centralized.
+gpg-agent.socket	user	Accepts standard GnuPG agent requests and activates `gpg-agent.service`. GnuPG clients connect here when they need private-key or passphrase operations.
+graphical-session-pre.target	user	Groups user services that must start before the graphical session is considered available.
+graphical-session.target	user	Marks the lifetime of the current graphical user session and groups services tied to it. Session services can bind themselves to this target so they stop together at logout.
+graphical.target	system	Starts a multi-user system together with its configured graphical login manager. It is the usual boot target for machines that present a graphical login screen.
+gssproxy.service	system	Provides Kerberos credential and GSS-API services to applications such as NFS without exposing keytabs directly. Privileged services ask it to perform authentication operations through a controlled local interface.
+gvfs-afc-volume-monitor.service	user	Detects Apple mobile devices accessible through the Apple File Conduit protocol for GVFS applications. This lets GNOME file managers show and browse compatible iPhones and iPads connected over USB.
+gvfs-daemon.service	user	Provides GNOME's virtual filesystem layer for accessing network shares, phones, trash, and other non-local locations. Applications use GVFS mounts through GIO and see them alongside ordinary local files.
+gvfs-goa-volume-monitor.service	user	Exposes storage from GNOME Online Accounts to GVFS applications. This makes configured online services appear as browseable locations in GNOME file pickers and file managers.
+gvfs-gphoto2-volume-monitor.service	user	Detects cameras accessible through gPhoto2 and exposes them to GVFS applications. GNOME file managers and photo tools use it to browse or import images from connected cameras.
+gvfs-metadata.service	user	Stores per-file metadata such as custom icons and file-manager attributes for GVFS clients. Nautilus and other GIO applications use this database for information that is not stored in the file itself.
+gvfs-mtp-volume-monitor.service	user	Detects phones and media players using the Media Transfer Protocol and exposes them to GVFS applications. This lets GNOME file managers browse and transfer files on compatible USB devices.
+gvfs-udisks2-volume-monitor.service	user	Tracks disks and removable media through UDisks and exposes them to GVFS applications. This is how GNOME file managers notice newly connected drives and present actions such as mounting and ejecting them.
+halt.target	system	Coordinates shutdown and stops the operating system without powering off the machine.
+hibernate.target	system	Coordinates services that prepare for and resume from system hibernation.
+httpd.service	system	Runs the Apache HTTP server under its Fedora and RHEL unit name, serving websites and forwarding configured application requests. It listens on configured HTTP and HTTPS endpoints and dispatches requests through Apache modules and virtual hosts.
+hybrid-sleep.target	system	Coordinates a sleep operation that both suspends to RAM and writes the system state to disk.
+iio-sensor-proxy.service	system	Reads accelerometers and ambient-light sensors and exposes their data to desktop applications. Desktop environments use its D-Bus interface for features such as automatic screen rotation and brightness adjustment.
+initrd-cleanup.service	system	Stops services in the initial RAM disk after the real root filesystem is ready. This clears initrd-only processes before control is fully transferred to the installed system.
+initrd-fs.target	system	Groups filesystems mounted by the initial RAM disk before switching to the real root.
+initrd-parse-etc.service	system	Reads mount configuration from the real root filesystem while still running in the initial RAM disk. It uses that configuration to generate the filesystem and swap units needed before switching root.
+initrd-root-device.target	system	Marks the root block device as available inside the initial RAM disk.
+initrd-root-fs.target	system	Marks the real root filesystem as mounted and ready inside the initial RAM disk.
+initrd-switch-root.service	system	Switches from the initial RAM disk to the real root filesystem and starts its system manager. This is the handoff from the temporary early-boot environment to the installed operating system.
+initrd-switch-root.target	system	Coordinates the transition from the initial RAM disk to the real root filesystem.
+initrd-udevadm-cleanup-db.service	system	Removes udev database state that should not be carried from the initial RAM disk into the real system. The real system's udev manager can then rebuild device state for its own runtime environment.
+initrd-usr-fs.target	system	Marks a separate `/usr` filesystem as available during initial-RAM-disk startup.
+initrd.target	system	Groups the normal startup units used within the initial RAM disk.
+ipp-usb.service	system	Exposes compatible USB printers as network-style IPP devices for driverless printing. Print clients discover the locally proxied device and communicate with it using the same IPP protocols used by network printers.
+irqbalance.service	system	Distributes hardware interrupt handling across processors to balance CPU load. It periodically adjusts IRQ affinities so interrupt-heavy devices do not unnecessarily concentrate work on one CPU.
+iscsid.service	system	Maintains iSCSI sessions and handles authentication and connection recovery for network block devices. iSCSI management tools use it to log in to remote storage targets and keep their connections alive.
+iscsid.socket	system	Accepts iSCSI management requests and activates the iSCSI daemon. Local iSCSI tools connect to this socket when they need session-management work from `iscsid.service`.
+kerneloops.service	system	Collects kernel oops reports from the system log and submits them to kerneloops.org. These reports describe recoverable kernel faults and help kernel developers identify recurring failures.
+kexec.target	system	Coordinates shutdown before booting directly into another kernel with `kexec`.
+keyboxd.service	user	Stores and searches GnuPG public keys on behalf of GnuPG clients. It centralizes access to the user's key database for operations such as importing keys and finding encryption recipients.
+keyboxd.socket	user	Accepts GnuPG public-key database requests and activates `keyboxd.service`. GnuPG clients connect here to query or update the shared key database.
+kmod-static-nodes.service	system	Creates static device nodes required by installed kernel modules early in boot. It derives the list from module metadata before dynamic device discovery is fully available.
+ldconfig.service	system	Rebuilds the dynamic linker's shared-library cache after system files change. The cache maps library names to installed files so dynamically linked programs can locate their dependencies efficiently.
+libvirtd.service	system	Runs the libvirt daemon, which manages virtual machines and their networks and storage. Tools such as `virsh` and graphical virtualization managers use its API to define, start, and inspect guests.
+libvirtd.socket	system	Accepts local libvirt management connections and activates the daemon. Libvirt clients connect to this socket to manage virtual machines, networks, and storage pools.
+lightdm.service	system	Runs the LightDM graphical login screen and starts desktop sessions. It authenticates users and launches the desktop environment selected at login.
+local-fs-pre.target	system	Provides an ordering point before local filesystems are checked and mounted.
+local-fs.target	system	Groups local filesystems that must be mounted during startup.
+logrotate.service	system	Rotates, compresses, and removes old log files according to logrotate configuration. Rotation keeps actively written logs bounded while retaining the configured number of older copies.
+logrotate.timer	system	Schedules regular log-file rotation. Each activation starts `logrotate.service` to process the system's configured log policies.
+machine.slice	system	Groups virtual machines and containers registered with systemd for resource accounting and control. Resource limits applied to this slice affect the machine workloads beneath it.
+machines.target	system	Groups services that manage local virtual machines and system containers. Machine-management services can join this target so their startup and shutdown are coordinated.
+man-db.service	system	Updates the index used by `man -k` and `apropos` to search installed manual pages. It scans installed manuals and records their names and short descriptions in the search database.
+man-db.timer	system	Schedules regular updates of the manual-page search index. Each activation starts `man-db.service` so newly installed or removed manuals are reflected in searches.
+modprobe@.service	system	Loads the kernel module named by the unit instance. Other units can depend on an instance when they require a particular kernel driver or subsystem.
+motd-news.service	system	Retrieves the news snippets included in Ubuntu's message of the day. The cached content is displayed by the login-time MOTD machinery in terminal sessions.
+motd-news.timer	system	Schedules retrieval of the news snippets included in Ubuntu's message of the day. Each activation refreshes the cache used when terminal logins assemble the MOTD.
+multi-user.target	system	Starts the non-graphical multi-user system, including normal system and network services. It represents a fully started system that can support multiple logins without requiring a graphical display manager.
+netplan-ovs-cleanup.service	system	Removes stale Open vSwitch interfaces before Netplan applies current network configuration. This prevents obsolete virtual interfaces from conflicting with the topology described by the current Netplan files.
+network-online.target	system	Marks the point when the configured network manager considers networking usable. Services that require configured connectivity can order themselves after this target rather than merely after the network stack starts.
+network-pre.target	system	Provides an ordering point for services that must run before network interfaces are configured.
+network.target	system	Marks that the network-management stack has started, without guaranteeing connectivity. Services use it to order themselves relative to network setup and teardown.
+networkd-dispatcher.service	system	Runs scripts in response to interface state changes reported by systemd-networkd. Administrators and packages place hooks in its state directories to react when links become routable, configured, or unavailable.
+networking.service	system	Configures network interfaces using the distribution's traditional ifupdown networking scripts. It applies `/etc/network/interfaces` during startup and tears those interfaces down during shutdown.
+nfs-client.target	system	Groups services required for mounting and using NFS filesystems as a client. NFS mount units can pull it in to ensure client-side name mapping and RPC support are available.
+nfs-idmapd.service	system	Maps NFSv4 user and group names between textual identities and local numeric IDs. This lets NFS clients and servers preserve file ownership across machines with compatible identity domains.
+nfs-server.service	system	Starts the kernel NFS server and exports configured filesystems to network clients. It coordinates the kernel server with the RPC and name-mapping services needed to handle client requests.
+nfs-utils.service	system	Acts as a common restart point for NFS client and server daemons from the nfs-utils package. Restarting it also restarts the active NFS services grouped beneath it.
+nftables.service	system	Loads the system's nftables firewall rules into the kernel. It applies the configured ruleset during startup so packets are filtered, translated, or classified as specified.
+nginx.service	system	Runs the nginx web server and reverse proxy. It listens on configured HTTP and HTTPS endpoints and either serves files directly or forwards requests to application servers.
+nmbd.service	system	Provides NetBIOS name service and network browsing for Samba clients and servers. It answers legacy NetBIOS name queries and advertises browse information on local networks.
+nscd.service	system	Caches name-service lookups for users, groups, hosts, and other NSS databases. Programs using the system Name Service Switch can reuse cached answers instead of repeatedly querying files or network identity sources.
+nss-lookup.target	system	Groups services that provide host and network-name lookup through the Name Service Switch.
+nss-user-lookup.target	system	Groups services that provide user and group lookup through the Name Service Switch.
+ntp.service	system	Synchronizes the system clock with network time servers using the ntpd daemon. It exchanges NTP packets with the servers and peers configured in `ntp.conf`.
+ntpd.service	system	Synchronizes the system clock with network time servers and can serve time to other machines. It exchanges NTP packets with the servers, peers, and clients allowed by its configuration.
+obex.service	user	Provides Bluetooth file transfer and object exchange through the BlueZ OBEX daemon. Desktop Bluetooth tools use it to send, receive, and browse files on paired devices.
+openvpn-client@.service	system	Starts an OpenVPN client connection from a named client configuration. Each instance creates and maintains the encrypted tunnel described by its configuration file.
+openvpn-server@.service	system	Starts an OpenVPN server from a named server configuration. Each instance accepts configured VPN clients and routes their traffic through an encrypted tunnel.
+openvpn.service	system	Acts as a grouping and reload point for OpenVPN tunnel instances. Starting or reloading it applies the operation to the tunnels managed by the distribution's OpenVPN unit setup.
+openvpn@.service	system	Starts an OpenVPN tunnel from a named configuration file. The instance may act as a client or server according to that file.
+org.freedesktop.IBus.session.GNOME.service	user	Runs the IBus input-method framework with GNOME integration for multilingual and complex text input. GNOME applications use it to switch input engines and compose characters that a keyboard layout does not provide directly.
+org.gnome.SettingsDaemon.Color.service	user	Applies monitor and device color profiles for the GNOME session. It works with the system color-management service so applications and displays use the selected calibration data.
+org.gnome.SettingsDaemon.Housekeeping.service	user	Removes expired temporary files and handles low-disk-space housekeeping for the GNOME session. It also produces the desktop's low-storage warnings when configured thresholds are reached.
+org.gnome.SettingsDaemon.Keyboard.service	user	Applies keyboard layout and input settings for the GNOME session. It keeps desktop preferences such as repeat behavior and accessibility options in sync with input devices.
+org.gnome.SettingsDaemon.MediaKeys.service	user	Handles GNOME media keys and desktop keyboard shortcuts. It translates key presses such as volume, brightness, and playback controls into actions for the desktop or media applications.
+org.gnome.SettingsDaemon.Power.service	user	Implements GNOME session power behavior such as idle dimming, suspend, and lid actions. It monitors session activity and power state, then requests the configured action through system power-management services.
+org.gnome.SettingsDaemon.PrintNotifications.service	user	Shows GNOME notifications for printer state, queued jobs, and printing problems. It watches the print service and reports events such as completed jobs, low supplies, or printer errors to the logged-in user.
+org.gnome.SettingsDaemon.Rfkill.service	user	Connects GNOME's airplane-mode controls to the kernel's Wi-Fi and Bluetooth radio switches. It keeps the desktop setting synchronized with hardware and software radio blocks.
+org.gnome.SettingsDaemon.ScreensaverProxy.service	user	Provides the GNOME interface applications use to inhibit the screensaver or idle actions. Media players and other applications call it when activity should keep the session awake.
+org.gnome.SettingsDaemon.Sharing.service	user	Starts and stops GNOME sharing services according to the current network and desktop settings. It controls facilities such as media sharing or remote login as the active network changes.
+org.gnome.SettingsDaemon.Smartcard.service	user	Monitors smart cards for the GNOME session and handles configured removal actions. It can lock the session or log the user out when an authentication card is removed.
+org.gnome.SettingsDaemon.Sound.service	user	Caches and plays desktop event sounds for the GNOME session. Other desktop components ask it to produce feedback for alerts and interface events.
+org.gnome.SettingsDaemon.UsbProtection.service	user	Enforces GNOME's policy for newly connected USB devices while the session is locked. It uses USBGuard to allow or reject devices according to the desktop's protection settings.
+org.gnome.SettingsDaemon.Wacom.service	user	Applies GNOME settings for Wacom tablets, styli, and pad buttons. It configures mappings, pressure behavior, and button actions as supported devices appear.
+org.gnome.SettingsDaemon.XSettings.service	user	Publishes GNOME appearance and toolkit settings to X11 applications through XSettings. This keeps themes, fonts, scaling, and related preferences consistent with the GNOME session.
+org.gnome.Shell@.service	user	Runs GNOME Shell, the desktop shell and Wayland compositor, for a named session. It draws the desktop interface, manages windows, and coordinates session features such as notifications and the overview.
+packagekit-offline-update.service	system	Applies package updates in a dedicated offline boot environment before the normal system starts. PackageKit stages the transaction beforehand, and this service records its result for the desktop update tool.
+packagekit.service	system	Provides a distribution-neutral package-management API used by graphical software and update tools. It translates requests to the system's native package manager and reports transaction progress over D-Bus.
+pam_namespace.service	system	Creates per-user or per-session filesystem namespaces configured through PAM. Login sessions use these namespaces to give users private views of selected directories.
+paths.target	both	Groups path-watching units active in the current systemd manager.
+pipewire-media-session.service	user	Runs PipeWire's original session manager, configuring devices and connecting audio and video streams. It applies policy when applications request streams or audio and video hardware appears.
+pipewire-pulse.service	user	Provides a PulseAudio-compatible server backed by PipeWire for applications using the PulseAudio protocol. Existing PulseAudio clients connect to it while PipeWire performs the underlying routing and device access.
+pipewire-pulse.socket	user	Listens for PulseAudio client connections and activates PipeWire's compatibility server.
+pipewire.service	user	Runs the per-user PipeWire media server that routes audio and video streams between applications and devices. A session manager such as WirePlumber supplies policy, while clients use PipeWire for low-latency media and screen capture.
+pipewire.socket	user	Listens for PipeWire client connections and activates the per-user media server.
+plasma-kded.service	user	Runs KDE's per-user service daemon, loading desktop modules for device, settings, and session integration. Its modules provide background features such as removable-device handling and reacting to configuration changes.
+plymouth-quit-wait.service	system	Waits for the graphical boot splash to finish before the display manager starts. This prevents the login screen from competing with Plymouth while it releases the display.
+plymouth-quit.service	system	Stops the Plymouth graphical boot splash when startup is complete. It returns control of the display to the login screen or console.
+plymouth-start.service	system	Starts the Plymouth graphical splash and prompts during boot. Boot services use Plymouth to display progress and request input such as disk-encryption passwords.
+podman.service	system	Provides the Podman API used to create and manage containers, images, and pods. Docker-compatible and Podman clients communicate with this service through its Unix socket.
+podman.socket	system	Listens for Podman API clients and activates the Podman service on demand.
+polkit.service	system	Evaluates authorization rules for privileged operations and coordinates authentication prompts for applications. System services consult it over D-Bus when an unprivileged user requests an action that needs additional authority.
+power-profiles-daemon.service	system	Exposes power-saver, balanced, and performance profiles and applies the selected platform power settings. Desktop power controls use its D-Bus API to show and change the active profile.
+poweroff.target	system	Coordinates shutdown and powers off the machine.
+printer.target	both	Groups units associated with printer hardware and printing services.
+proc-sys-fs-binfmt_misc.automount	system	Mounts the kernel's `binfmt_misc` interface on first access so executable-format handlers can be registered.
+pulseaudio.service	user	Runs the per-user PulseAudio sound server, routing audio streams between applications and devices. It mixes playback, captures microphone input, and exposes per-application volume controls to the desktop.
+pulseaudio.socket	user	Listens for PulseAudio client connections and activates the per-user sound server.
+qemu-guest-agent.service	system	Exchanges status and control messages between a QEMU virtual machine and its host. Management software uses the agent to query guest state and request operations such as filesystem freezing or orderly shutdown.
+qemu-kvm.service	system	Prepares kernel modules and host settings used to run QEMU virtual machines with KVM acceleration. Virtualization tools rely on that kernel support to execute guest code using hardware virtualization.
+quotaon.service	system	Enables configured filesystem disk quotas during boot. Once active, the kernel tracks and enforces the user, group, or project limits stored on each filesystem.
+rc-local.service	system	Runs commands from `/etc/rc.local` late in boot for compatibility with older startup setups. It provides a systemd entry point for locally configured commands written for the traditional rc.local mechanism.
+reboot.target	system	Coordinates shutdown and reboots the machine.
+remote-cryptsetup.target	system	Groups encrypted block devices required by remote filesystems.
+remote-fs-pre.target	system	Provides an ordering point before remote filesystems are mounted.
+remote-fs.target	system	Groups network and other remote filesystems mounted during startup.
+remote-veritysetup.target	system	Groups integrity-verified block devices required by remote filesystems.
+rescue.service	system	Starts a single-user recovery shell with the basic local filesystems mounted. An administrator can use the shell to repair configuration or storage problems without starting the normal service set.
+rescue.target	system	Provides a single-user recovery environment with basic system services and local filesystems. It brings up `rescue.service` and the minimal dependencies needed for an administrative shell.
+rpc-gssd.service	system	Handles Kerberos authentication for NFS clients using RPCSEC_GSS. It obtains credentials and creates the security contexts used to authenticate requests to protected NFS exports.
+rpc-statd-notify.service	system	Notifies NFS peers after a reboot so interrupted file locks can be recovered. It sends the local host's new status-monitor state to machines recorded before shutdown or failure.
+rpc-statd.service	system	Tracks NFSv2 and NFSv3 file locks and coordinates lock recovery after crashes. NFS locking services register peers with it so both sides can reclaim locks after either machine restarts.
+rpc-svcgssd.service	system	Handles Kerberos authentication for the NFS server using RPCSEC_GSS. It establishes security contexts that let the server verify clients accessing Kerberos-protected exports.
+rpcbind.service	system	Maps ONC RPC program numbers to the network ports used by services such as NFS. RPC clients query it to discover where a requested server program is listening.
+rpcbind.socket	system	Listens for RPC port-mapping requests and activates `rpcbind.service`.
+rpcbind.target	system	Groups the RPC port-mapping service and its dependencies.
+rsync.service	system	Runs rsync as a network daemon for configured file-transfer modules. Remote clients connect to those named modules to list, upload, or download files according to their access rules.
+rsyslog.service	system	Collects syslog messages and routes them to text files, remote log servers, or other configured destinations. It receives records from local applications and sockets, then filters and formats them according to `rsyslog.conf`.
+rtkit-daemon.service	system	Grants controlled real-time scheduling priority to audio and other latency-sensitive user processes. Clients such as sound servers request priority over D-Bus, and RTKit applies policy and resource limits before granting it.
+runlevel0.target	system	Provides the SysV-compatible alias for the target that halts or powers off the system.
+runlevel1.target	system	Provides the SysV-compatible alias for the single-user rescue target.
+runlevel2.target	system	Provides a SysV-compatible alias for a distribution-defined multi-user target.
+runlevel3.target	system	Provides the SysV-compatible alias for the non-graphical multi-user target.
+runlevel4.target	system	Provides a SysV-compatible alias for a distribution-defined multi-user target.
+runlevel5.target	system	Provides the SysV-compatible alias for the graphical target.
+runlevel6.target	system	Provides the SysV-compatible alias for the reboot target.
+samba-ad-dc.service	system	Runs Samba as an Active Directory domain controller, providing directory, authentication, DNS, and file services. Windows and Samba clients use it to join the domain, authenticate users, and discover domain resources.
+saned.socket	system	Listens for network scanner requests and activates a SANE server instance.
+saned@.service	system	Serves a network scanner client using the SANE scanning interface. A socket-activated instance accesses locally configured scanner hardware and returns image data to the remote client.
+sddm.service	system	Runs the SDDM graphical login screen and starts desktop sessions, commonly for KDE Plasma. It authenticates the selected user and launches the requested X11 or Wayland session.
+serial-getty@.service	system	Provides a login prompt on a serial console, with one instance for each serial device. It lets a user authenticate through a physical serial port or a virtual machine's serial console.
+session.slice	user	Groups the core services of a user's login session for resource management. systemd places these processes in a shared cgroup hierarchy for accounting and resource controls.
+shutdown.target	both	Coordinates the ordered stopping of services and unmounting of filesystems during shutdown.
+sigpwr.target	system	Handles a power-failure signal reported by the kernel or an uninterruptible power supply.
+sleep.target	system	Groups services that prepare for and resume from any system sleep operation.
+slices.target	system	Groups the slice units that define systemd's control-group hierarchy.
+smartcard.target	both	Groups units associated with smart-card hardware and services.
+smb.service	system	Provides SMB file and printer sharing through Samba. Network clients use the SMB protocol to access the shares and printers defined in the Samba configuration.
+smbd.service	system	Serves SMB file and printer shares to Windows, macOS, and Linux clients through Samba. It handles authenticated client sessions and performs file operations against the configured local paths.
+snapd.apparmor.service	system	Loads and updates AppArmor profiles generated for installed snap packages. These profiles enforce the filesystem, device, and interface restrictions declared by each snap.
+snapd.seeded.service	system	Marks completion of snapd's initial installation of preseeded snaps and assertions. Other boot work can use this marker to wait until the image's bundled snap state has been imported.
+snapd.service	system	Installs, updates, removes, and launches snap packages and manages their system integration. The `snap` client and desktop tools send requests to its local API, while snapd handles downloads, mounts, and refresh scheduling.
+snapd.socket	system	Listens for snap client API requests and activates the snapd daemon.
+sockets.target	both	Groups socket-listening units active in the current systemd manager.
+sound.target	both	Groups units associated with detected sound hardware.
+speech-dispatcher.service	both	Provides a shared interface through which applications send text to speech synthesizers. Accessibility tools submit text and speech settings to it, and it routes the request to the configured synthesizer backend.
+speech-dispatcher.socket	user	Listens for speech-synthesis client connections and activates Speech Dispatcher.
+spice-vdagentd.service	system	Coordinates clipboard, display resizing, and other desktop integration between SPICE virtual-machine guests and hosts. It relays messages between the host's SPICE client and the per-session guest agent.
+spice-vdagentd.socket	system	Listens for SPICE guest-agent connections and activates its system daemon.
+ssh-agent.service	user	Holds decrypted SSH private keys and performs authentication operations for the user session. SSH clients ask the agent to sign authentication challenges without reading the private keys themselves.
+ssh.service	system	Runs the OpenSSH server and accepts incoming secure shell and file-transfer connections. It authenticates remote users and starts their shell, command, SFTP, or forwarding session.
+ssh.socket	system	Listens for incoming SSH connections and activates the OpenSSH server on demand.
+sshd-keygen.service	system	Generates missing host keys used by the OpenSSH server to identify the machine. The SSH server presents these persistent keys so clients can recognize the host on later connections.
+sshd-keygen.target	system	Groups the tasks that generate missing OpenSSH server host keys.
+sshd-keygen@.service	system	Generates one type of OpenSSH server host key, selected by the unit instance. Separate instances create algorithms such as RSA, ECDSA, or Ed25519 before the server starts.
+sshd.service	system	Runs the OpenSSH server and accepts incoming secure shell and file-transfer connections. It authenticates remote users and starts their shell, command, SFTP, or forwarding session.
+sshd.socket	system	Listens for incoming SSH connections and activates the OpenSSH server on demand.
+suspend-then-hibernate.target	system	Coordinates a sleep operation that suspends first and hibernates after a configured delay.
+suspend.target	system	Coordinates services that prepare for and resume from suspend-to-RAM.
+swap.target	system	Groups swap devices and swap files activated during startup.
+switcheroo-control.service	system	Exposes GPU information and controls used to launch applications on a selected GPU in hybrid-graphics systems. Desktop environments use its D-Bus API to offer choices such as integrated or discrete graphics when starting an application.
+sysinit.target	system	Groups early system initialization such as mounts, swap, device setup, and kernel configuration. Most ordinary services start only after this foundational boot work has completed.
+syslog.socket	system	Receives local syslog messages and passes them to the configured logging service. Its stable socket path lets applications emit logs before a particular syslog daemon has started.
+sysstat-collect.service	system	Collects a snapshot of system performance counters for sysstat history. It runs `sadc` to append CPU, memory, disk, network, and other activity data to the current daily file.
+sysstat-collect.timer	system	Schedules regular collection of sysstat performance counters. Each timer firing starts `sysstat-collect.service` to add another sample to the daily history.
+sysstat-summary.service	system	Generates a daily summary from collected sysstat performance data. It processes the previous day's activity file into the report used by sysstat's summary tooling.
+sysstat-summary.timer	system	Schedules generation of the daily sysstat summary. It starts `sysstat-summary.service` once per day after the collection period closes.
+system-getty.slice	system	Groups processes belonging to local text-console login prompts. The slice lets systemd account for and limit their resources as a group.
+system-modprobe.slice	system	Groups kernel-module loading jobs started from systemd templates. These short-lived jobs run when another unit requests a particular module.
+system-update-cleanup.service	system	Removes the marker that requested an offline system update after the update finishes. This returns the next boot to the normal default target.
+system-update-pre.target	system	Groups preparation performed immediately before an offline system update. Update implementations can order setup work before this target is reached.
+system-update.target	system	Boots into the restricted environment used to install an offline system update. Package managers redirect a reboot here after staging updates that must run without the normal system active.
+system.slice	system	Groups system services so their resources can be accounted for and controlled separately from users and virtual machines. Most services started by the system manager are placed beneath this cgroup.
+systemd-ask-password-console.path	system	Watches for boot-time password requests that should be displayed on the system console. A request appearing in systemd's password directory activates the corresponding prompt service.
+systemd-ask-password-console.service	system	Prompts for pending boot-time passwords on the system console and returns them to requesting services. It is commonly used for encrypted disks and credentials needed before a graphical session exists.
+systemd-ask-password-plymouth.path	system	Watches for boot-time password requests that should be forwarded to Plymouth. It activates the Plymouth prompt service when a request appears.
+systemd-ask-password-plymouth.service	system	Forwards pending boot-time password prompts to the Plymouth splash screen. This lets encrypted-volume and other early-boot prompts appear in the graphical boot interface.
+systemd-ask-password-wall.path	system	Watches for boot-time password requests that should be broadcast to logged-in terminals. It activates the wall-based prompt helper when a request appears.
+systemd-ask-password-wall.service	system	Broadcasts pending system password prompts to logged-in terminal users. Replies are returned to the service waiting for the credential.
+systemd-backlight@.service	system	Saves and restores the brightness of a display backlight or LED device across boots. Each instance corresponds to one brightness device exposed by the kernel.
+systemd-binfmt.service	system	Registers handlers for additional executable formats with the kernel's `binfmt_misc` interface. Rules from `binfmt.d` can launch interpreters for formats such as foreign binaries or bytecode.
+systemd-bless-boot.service	system	Marks the current boot as successful for systemd-boot's boot-attempt counting. A successful mark prevents the boot loader from falling back after the configured number of failed attempts.
+systemd-boot-check-no-failures.service	system	Checks whether the system booted without failed units before marking the boot successful. It participates in systemd-boot's automatic boot assessment.
+systemd-bsod.service	system	Displays a full-screen emergency message and diagnostic information after a critical boot failure. It gives the user an error summary when the normal interface is unavailable.
+systemd-coredump.socket	system	Receives process core dumps and starts systemd's core-dump handler. The socket allows crashes to be captured without keeping a handler process running continuously.
+systemd-coredump@.service	system	Records and processes one process core dump. Depending on `coredump.conf`, it stores the dump externally or in the journal together with process metadata for tools such as `coredumpctl`.
+systemd-exit.service	both	Instructs a per-user or container systemd manager to exit. It is started as the manager's units are shut down and returns an exit status to the process that launched the manager.
+systemd-firstboot.service	system	Initializes settings such as locale, hostname, machine ID, and root password on a new system image. Image builders and first-boot workflows use it before those settings have been populated.
+systemd-fsck-root.service	system	Checks the root filesystem for errors before it is remounted for normal use. The check follows the filesystem's configured repair policy and can redirect boot into recovery when errors remain.
+systemd-fsck@.service	system	Checks a filesystem for errors before it is mounted, with one instance for each device. Results determine whether mounting can continue or startup must enter recovery.
+systemd-fsckd.service	system	Collects progress reports from filesystem checks and forwards them to the console or boot splash. It combines updates from checks running in parallel into one progress stream.
+systemd-fsckd.socket	system	Receives progress updates from filesystem-checking processes for `systemd-fsckd.service`. Connecting to the socket starts the progress daemon on demand.
+systemd-growfs-root.service	system	Expands the root filesystem to fill its backing block device during boot. This lets a system image automatically consume space added when it is deployed to a larger disk.
+systemd-growfs@.service	system	Expands a configured filesystem to fill its backing block device. Each instance operates on the mount point encoded in its unit name.
+systemd-halt.service	system	Performs the final userspace steps before halting the machine. It hands control to the kernel after services have stopped and filesystems have been unmounted.
+systemd-hibernate-resume.service	system	Restores a saved system image from a hibernation device during early boot. If a valid image is found, the kernel resumes the previous session instead of continuing a fresh boot.
+systemd-hibernate-resume@.service	system	Restores a saved system image from the hibernation device named by the unit instance. It runs in early boot before filesystems and normal services start.
+systemd-hibernate.service	system	Writes system memory to disk and powers down the machine for hibernation. Sleep hooks and device preparation run before systemd asks the kernel to save the image.
+systemd-hostnamed.service	system	Provides a D-Bus API for reading and changing the machine hostname and related metadata. Tools such as `hostnamectl` and desktop settings panels use this service.
+systemd-hwdb-update.service	system	Rebuilds udev's compiled hardware database from installed device metadata. Udev consults the result to attach model names, capabilities, and other properties to detected hardware.
+systemd-hybrid-sleep.service	system	Writes system memory to disk and then suspends the machine to RAM. The machine can resume quickly while retaining the hibernation image if power is lost.
+systemd-importd.service	system	Imports, exports, and downloads disk images used by containers, virtual machines, and portable services. Commands such as `machinectl pull-*` use its D-Bus interface for image transfers.
+systemd-initctl.service	system	Provides compatibility for software using the legacy SysV `initctl` interface. It translates supported requests into corresponding systemd operations.
+systemd-initctl.socket	system	Receives requests on the legacy `initctl` interface and activates its compatibility service. This preserves the named-pipe interface expected by older software.
+systemd-journal-catalog-update.service	system	Rebuilds the journal message catalog used to add explanatory text to structured log messages. It runs after packages install or update catalog files.
+systemd-journal-flush.service	system	Flushes journal records from volatile memory storage to persistent disk storage early in boot. This moves messages collected before persistent filesystems were ready into the on-disk journal.
+systemd-journald-audit.socket	system	Receives Linux Audit messages from the kernel for storage in the system journal. It lets `journalctl` show audit records alongside other system logs.
+systemd-journald-dev-log.socket	system	Receives traditional syslog messages sent to `/dev/log` for storage in the journal. Programs using the syslog API write through this socket.
+systemd-journald-varlink@.socket	system	Receives Varlink requests for the journal namespace named by the unit instance. Clients use it to access namespace-specific journal services.
+systemd-journald.service	system	Collects logs from services, the kernel, and syslog clients and stores them in the system journal. `journalctl` reads these structured records and can filter them by unit, boot, priority, and other metadata.
+systemd-journald.socket	system	Receives native journal messages and standard output streams from services. Socket activation makes the logging endpoint available before the journal daemon itself has started.
+systemd-journald@.service	system	Runs a separate journal namespace for services assigned to that namespace. Namespaces keep selected log streams and retention settings separate from the default system journal.
+systemd-journald@.socket	system	Receives journal messages for the journal namespace named by the unit instance. Connecting services are routed to the matching namespaced journal daemon.
+systemd-kexec.service	system	Performs the final operation that starts a kernel previously loaded with `kexec`. It bypasses firmware initialization and the normal boot loader after shutdown has stopped running services.
+systemd-localed.service	system	Provides a D-Bus API for reading and changing system locale and console keyboard settings. `localectl` and desktop settings panels use it to update the corresponding configuration files.
+systemd-logind.service	system	Tracks users, sessions, and seats and handles power keys, lid switches, and device access for logged-in users. Desktop environments and `loginctl` use its D-Bus API to inspect sessions and request suspend, reboot, or shutdown operations.
+systemd-machine-id-commit.service	system	Commits a temporary machine ID to persistent storage once the root filesystem is writable. This preserves the identity generated earlier when `/etc` was read-only or transient.
+systemd-machined.service	system	Tracks local virtual machines and system containers and exposes them through `machinectl` and D-Bus. It records their names, addresses, resource usage, and lifecycle state for management tools.
+systemd-modules-load.service	system	Loads kernel modules named in `modules-load.d` configuration during boot. Packages and administrators use these files for modules that must be present without waiting for hardware-driven loading.
+systemd-network-generator.service	system	Generates systemd-networkd configuration from network settings supplied on the kernel command line. This is used when an initrd or image must bring up networking before ordinary configuration is available.
+systemd-networkd-wait-online.service	system	Waits until systemd-networkd reports that configured links have reached their required state. It delays `network-online.target` for services that declare they need usable networking at startup.
+systemd-networkd-wait-online@.service	system	Waits for a selected network interface managed by systemd-networkd to become configured. Each instance limits the online check to the interface encoded in its name.
+systemd-networkd.service	system	Configures network links, addresses, routes, and related settings from `.network` and `.netdev` files. It also reports link state to other services through D-Bus and its runtime state files.
+systemd-networkd.socket	system	Listens for kernel notifications about links, addresses, and routes and activates `systemd-networkd.service` when they arrive.
+systemd-nspawn@.service	system	Starts the systemd-nspawn container named by the unit instance. Container settings and the matching filesystem image determine its networking, resources, and startup command.
+systemd-oomd.service	system	Monitors cgroup memory pressure and kills selected processes before memory exhaustion makes the system unresponsive. Units opt into its policy through systemd resource-control settings such as `ManagedOOMMemoryPressure`.
+systemd-oomd.socket	system	Accepts registrations for cgroups managed by `systemd-oomd` and activates the daemon. Systemd managers use it to communicate which cgroups and out-of-memory policies should be monitored.
+systemd-pcrmachine.service	system	Measures the machine ID into a TPM platform configuration register as part of measured boot. This contributes the installation's identity to TPM policies used for protected credentials and secrets.
+systemd-pcrphase-initrd.service	system	Measures the initial-RAM-disk boot phase into a TPM platform configuration register. The marker lets TPM policies distinguish operations performed inside the initrd from later boot phases.
+systemd-pcrphase-sysinit.service	system	Measures the early system-initialization phase into a TPM platform configuration register. TPM policies can use the transition to release secrets only after the real system has begun initialization.
+systemd-pcrphase.service	system	Measures boot-phase transitions into TPM platform configuration registers for measured-boot policies. These markers allow secrets to be bound to particular stages of a trusted boot sequence.
+systemd-portabled.service	system	Attaches and manages portable service images through `portablectl` and D-Bus. It connects an image's unit files to the host while keeping the image's application files self-contained.
+systemd-poweroff.service	system	Performs the final userspace steps before powering off the machine. It hands control to the kernel after services have stopped and filesystems have been unmounted.
+systemd-pstore.service	system	Archives crash and diagnostic records left by firmware or the kernel in persistent platform storage. It moves records from pstore into the journal and filesystem so they survive subsequent reboots for inspection.
+systemd-quotacheck.service	system	Checks filesystem quota metadata before quotas are enabled. It rebuilds inconsistent usage information so per-user and per-group limits start with accurate accounting.
+systemd-random-seed.service	system	Restores an entropy seed during boot and saves a new seed during shutdown for the kernel random-number generator. Carrying the seed across boots helps the generator initialize securely before other entropy sources are available.
+systemd-reboot.service	system	Performs the final userspace steps before rebooting the machine. It asks the kernel to restart after services have stopped and filesystems have been unmounted.
+systemd-remount-fs.service	system	Remounts the root and kernel API filesystems with their configured options early in boot. This applies `/etc/fstab` settings to filesystems mounted earlier by the kernel or initrd.
+systemd-repart.service	system	Creates or grows disk partitions according to repartition configuration, commonly during image-based boot. It lets one generic image adapt its partition layout and filesystems to the disk where it is deployed.
+systemd-resolved.service	system	Provides local DNS resolution, caching, and per-interface DNS routing to applications. Network managers supply DNS servers and search domains, while clients use the stub resolver, NSS, or D-Bus interfaces.
+systemd-rfkill.service	system	Saves and restores the blocked or unblocked state of wireless radios across boots. Each state file corresponds to a kernel rfkill device such as a Wi-Fi or Bluetooth adapter.
+systemd-rfkill.socket	system	Watches the kernel rfkill interface and activates the service that persists radio state. Events arrive when radios appear or their blocked state changes.
+systemd-suspend-then-hibernate.service	system	Suspends the machine to RAM and hibernates it later after a configured delay. This provides quick resume for short sleeps while preserving the session on disk for longer ones.
+systemd-suspend.service	system	Performs the kernel operation that suspends the machine to RAM. It runs configured sleep hooks and freezes user sessions before handing control to the kernel.
+systemd-sysctl.service	system	Applies kernel settings from `sysctl.d` configuration during boot. These settings control networking, virtual memory, security behavior, and other kernel subsystems exposed through `/proc/sys`.
+systemd-sysext.service	system	Merges system-extension images into `/usr` and `/opt` using overlay mounts. Extensions can add version-matched system files without modifying the underlying operating-system image.
+systemd-sysusers.service	system	Creates system users and groups declared in `sysusers.d` configuration. Packages and system images use these declarative records instead of running account-creation scripts.
+systemd-time-wait-sync.service	system	Waits until a time-synchronization service reports that the system clock is synchronized. It delays `time-sync.target` for units that require trustworthy wall-clock time.
+systemd-timedated.service	system	Provides a D-Bus API for changing the system clock, time zone, and network-time settings. `timedatectl` and desktop settings panels use it to update time configuration.
+systemd-timesyncd.service	system	Synchronizes the system clock with network time servers using a lightweight SNTP client. It obtains per-link servers from network configuration and reports synchronization state to systemd.
+systemd-tmpfiles-clean.service	both	Removes aged files and directories according to `tmpfiles.d` cleanup rules. System and user managers run it for temporary data within their respective scopes.
+systemd-tmpfiles-clean.timer	both	Schedules regular cleanup of temporary and volatile files. It starts the matching cleanup service in the system or user manager.
+systemd-tmpfiles-setup-dev.service	system	Creates static device nodes and applies ownership and permissions from `tmpfiles.d` rules. It runs early so required entries under `/dev` exist before dependent services start.
+systemd-tmpfiles-setup.service	both	Creates volatile files and directories and applies ownership and permissions from `tmpfiles.d` rules during manager startup. Packages use these declarations for runtime paths, caches, locks, and other state that may not survive a reboot or logout.
+systemd-tpm2-setup-early.service	system	Creates or loads the TPM2 storage root key early in boot for services that need it. The key becomes the parent for TPM objects created before the normal system is fully initialized.
+systemd-tpm2-setup.service	system	Creates or loads the TPM2 storage root key and records its public information for system services. Other components use this stable key hierarchy when sealing credentials and encryption material to the TPM.
+systemd-udev-settle.service	system	Waits until udev has finished processing the device events currently queued. Storage and older hardware-management services use it when they cannot react to devices asynchronously.
+systemd-udev-trigger.service	system	Replays kernel device events during boot so udev applies rules to hardware already present. This coldplug pass creates device nodes and starts device-dependent units for hardware detected before udev began listening.
+systemd-udevd-control.socket	system	Receives control commands for the systemd-udev device manager. Tools use it to reload rules, adjust logging, and manage the event queue.
+systemd-udevd-kernel.socket	system	Receives kernel device events for processing by the systemd-udev device manager. Events describe hardware being added, removed, or changed.
+systemd-udevd.service	system	Processes hardware events, creates device nodes, applies permissions, and triggers configured device actions. Its rules also attach metadata and start systemd units associated with newly available devices.
+systemd-update-done.service	system	Marks completion of first-boot update tasks after `/etc` and `/var` have been populated. It prevents image-initialization work from being repeated on later boots.
+systemd-update-utmp-runlevel.service	system	Records changes of the SysV-compatible runlevel in the utmp and wtmp login-accounting files. Legacy tools read these records to show transitions between system operating modes.
+systemd-update-utmp.service	system	Records system boot and shutdown events in the utmp and wtmp login-accounting files. Commands such as `who` and `last` use this accounting history.
+systemd-user-sessions.service	system	Allows normal user logins after startup and blocks new logins during shutdown. It does this by creating or removing the system's `nologin` marker at the appropriate point in the boot lifecycle.
+systemd-vconsole-setup.service	system	Applies the configured font and keyboard map to a Linux virtual console. It runs when consoles appear so text login prompts use the system's selected layout and display settings.
+systemd-volatile-root.service	system	Makes the root filesystem transient by placing a writable in-memory layer over a read-only root. Changes made during the boot disappear when the machine restarts.
+thermald.service	system	Monitors Intel thermal sensors and adjusts cooling and power controls to keep hardware within temperature limits. It uses platform thermal data to reduce heat before the kernel must apply more severe throttling.
+time-set.target	system	Marks the point when the system clock has been set from a local source and is approximately correct.
+time-sync.target	system	Marks the point when the system clock has been synchronized with an accurate external source.
+timers.target	both	Groups timer units active in the current systemd manager.
+tlp.service	system	Applies TLP's laptop power-management settings to processors, radios, storage, and other devices. It reapplies the appropriate battery or AC-power profile when the power source changes.
+tmp.mount	system	Mounts the filesystem used for `/tmp` when it is configured as a separate or temporary mount. Other units can order themselves after it before creating temporary files.
+udisks2.service	system	Manages disks and removable media and provides mounting, formatting, and inspection operations to desktop applications. File managers and disk utilities use its D-Bus API to handle drives without performing privileged operations themselves.
+ufw.service	system	Loads firewall rules configured through the Uncomplicated Firewall during boot. It translates the saved UFW policy into the packet-filtering rules enforced by the kernel.
+umount.target	system	Coordinates unmounting filesystems and disabling swap during shutdown.
+unattended-upgrades.service	system	Finishes or shuts down automatic APT package upgrades cleanly during system shutdown. It prevents a poweroff or reboot from interrupting package database changes at an unsafe point.
+upower.service	system	Tracks batteries and other power devices and exposes charge, status, and energy information to desktop applications. Desktop indicators and power settings use its D-Bus API to estimate remaining runtime and respond to low-battery conditions.
+usb-gadget.target	system	Groups services that configure the machine to act as a USB peripheral through the Linux USB gadget framework. Gadget configurations can expose functions such as networking, storage, or a serial port to a connected host.
+usb_modeswitch@.service	system	Switches a USB mobile-broadband device from storage mode into modem mode when it is connected. Each instance sends the device-specific command needed to reveal its communications interfaces.
+usbmuxd.service	system	Multiplexes connections from applications to iPhones and other iOS devices over USB. Tools for synchronization, development, and file access share the device connection through its local socket.
+user-runtime-dir@.service	system	Creates and removes a user's `/run/user/UID` runtime directory around their login sessions. The directory holds sockets, locks, and other per-user state that should not survive a reboot.
+user.slice	system	Groups all logged-in users and their sessions for resource accounting and control. Each user's manager and session scopes are placed beneath this cgroup hierarchy.
+user@.service	system	Runs a per-user systemd manager that starts and supervises the user's session services. Each instance owns units such as PipeWire, desktop portals, and keyring agents for one user and may remain running after logout when lingering is enabled.
+uuidd.service	system	Generates UUIDs for local clients and coordinates time-based UUID generation across processes. Central coordination prevents duplicate timestamp-based UUIDs when many processes request them concurrently.
+uuidd.socket	system	Accepts UUID generation requests and activates `uuidd.service`. Programs using libuuid can connect to this socket when coordinated generation is needed.
+veritysetup-pre.target	system	Provides an ordering point before local dm-verity integrity-protected volumes are activated.
+veritysetup.target	system	Groups local dm-verity integrity-protected block devices activated during startup.
+whoopsie.path	system	Watches Ubuntu's crash-report directory and starts the report uploader when a report appears. This avoids keeping the uploader running while there is nothing to submit.
+whoopsie.service	system	Uploads collected Ubuntu crash reports to Ubuntu's error-tracking service. It reads reports prepared by Apport and submits the diagnostic fields used to group recurring failures.
+wireplumber.service	user	Runs PipeWire's session manager, discovering devices and deciding how media streams and nodes are connected. It applies policy for default devices, audio profiles, permissions, and routing when hardware or applications change.
+wpa_supplicant-nl80211@.service	system	Runs a WPA supplicant instance for a Wi-Fi interface using the kernel's nl80211 driver interface. The instance performs scanning, association, and WPA or 802.1X authentication for that interface.
+wpa_supplicant-wired@.service	system	Runs a WPA supplicant instance for 802.1X authentication on a wired interface. It exchanges EAP credentials with the network before normal traffic is permitted.
+wpa_supplicant.service	system	Handles Wi-Fi authentication and association on behalf of network-management software. NetworkManager and similar clients configure connections through its control or D-Bus interfaces.
+wpa_supplicant@.service	system	Runs a WPA supplicant instance for a named network interface. Each instance handles association and WPA or 802.1X authentication for that interface.
+xdg-desktop-autostart.target	user	Groups desktop applications launched from XDG autostart files for the current user session.
+xdg-desktop-portal-gnome.service	user	Implements desktop portal dialogs and GNOME integration for sandboxed applications. It provides GNOME-native interfaces for choosing files, capturing screens, and other mediated desktop operations.
+xdg-desktop-portal-gtk.service	user	Implements GTK file chooser and other desktop portal interfaces for sandboxed applications. The main portal broker selects it when the current desktop requests the GTK backend.
+xdg-desktop-portal-kde.service	user	Implements desktop portal dialogs and KDE Plasma integration for sandboxed applications. It supplies Plasma-native file choosers, screen sharing, and other mediated desktop operations.
+xdg-desktop-portal.service	user	Brokers controlled access from sandboxed applications to files, screenshots, screen sharing, and other desktop features. It chooses a desktop-specific backend and returns only the resources approved through that interface.
+xdg-document-portal.service	user	Grants sandboxed applications access to individual files selected by the user through a shared document store. It exposes stable paths inside application sandboxes without granting access to the surrounding filesystem.
+xdg-permission-store.service	user	Stores persistent permission decisions made through desktop portal interfaces. Portal backends consult it for choices such as device access, background activity, and previously selected resources.
+zfs-import-cache.service	system	Imports ZFS storage pools listed in the system's pool cache during boot. The cache records the devices that belonged to previously known pools so they can be located without a full scan.
+zfs-import-scan.service	system	Scans available devices and imports discovered ZFS storage pools during boot. It provides a fallback when no usable pool cache is available.
+zfs-mount.service	system	Mounts filesystems from imported ZFS storage pools. Dataset properties determine mount points and which filesystems are mounted automatically.
+zfs.target	system	Groups the services required to import ZFS pools and mount their filesystems. Other units can order themselves after this target when they need ZFS storage ready.

--- a/src/assets/unit-descriptions.tsv
+++ b/src/assets/unit-descriptions.tsv
@@ -12,7 +12,7 @@ acpid.service	system	Handles ACPI events from the kernel, such as power-button p
 acpid.socket	system	Accepts ACPI event connections and activates `acpid.service` when they arrive.
 alsa-restore.service	system	Restores saved ALSA sound-card mixer settings during boot. This preserves volume, mute, and other hardware controls across restarts.
 alsa-state.service	system	Runs the ALSA state daemon to save and restore sound-card mixer settings as hardware appears and disappears. It preserves controls such as volume and mute across restarts.
-anacron.service	system	Runs periodic jobs that became due while the computer was powered off. It reads the system anacrontab and records completion timestamps to avoid running a job more often than configured.
+anacron.service	system	Runs periodic jobs that became due while the computer was powered off. Cron runs jobs only at their scheduled times, while anacron makes sure missed daily, weekly, and monthly jobs run later.
 anacron.timer	system	Checks periodically for overdue jobs and starts `anacron.service`.
 apache2.service	system	Runs the Apache HTTP server under its Debian and Ubuntu unit name. It serves configured websites and can proxy requests to application servers.
 app.slice	user	Groups a user's application processes so systemd can account for and manage their resources separately. Desktop session managers commonly place launched applications beneath this slice.
@@ -21,7 +21,7 @@ apport-autoreport.path	system	Watches for pending Ubuntu crash reports and start
 apport-autoreport.service	system	Processes pending Ubuntu crash reports through Apport's automatic reporting workflow. It reads reports collected after crashes and submits eligible diagnostic data to Ubuntu's error tracker.
 apport-autoreport.timer	system	Periodically starts automatic processing of pending Ubuntu crash reports.
 apport.service	system	Collects diagnostic information when a program crashes and prepares an Ubuntu crash report. The report combines the crash data with package, process, and system details used for diagnosis.
-apt-daily-upgrade.service	system	Installs available updates and performs package cleanup through APT's unattended-upgrade machinery. It is normally started by `apt-daily-upgrade.timer` and uses the same APT configuration as manually initiated upgrades.
+apt-daily-upgrade.service	system	Installs available updates and performs package cleanup through APT's unattended-upgrade machinery. This keeps installed packages updated without someone having to start each upgrade manually.
 apt-daily-upgrade.timer	system	Schedules the daily APT unattended-upgrade and cleanup job.
 apt-daily.service	system	Refreshes APT package metadata and downloads package updates in the background. It is normally started by `apt-daily.timer`, making current repository information available to other package-management tools.
 apt-daily.timer	system	Schedules the daily APT package download job.
@@ -33,22 +33,24 @@ autovt@.service	system	Starts a text login prompt on a virtual terminal when tha
 avahi-daemon.service	system	Implements multicast DNS and DNS service discovery on the local network. Applications use it to advertise and find devices and services such as printers without conventional DNS configuration.
 avahi-daemon.socket	system	Receives local Avahi client connections and activates the Avahi daemon on demand.
 background.slice	user	Groups low-priority background services in a user's systemd manager for resource management. Desktop components can place non-interactive work here so it receives different scheduling and memory policy from foreground applications.
-basic.target	both	Marks the point in startup when basic services, sockets, paths, and timers are available.
+basic.target	both	Marks the point in startup when fundamental services, sockets, paths, and timers are available. Most regular system and user services start after this shared foundation is ready.
 binfmt-support.service	system	Registers handlers that let the kernel launch additional executable formats through `binfmt_misc`. Configured interpreters can then handle files such as foreign binaries or bytecode when they are executed directly.
-blockdev@.target	system	Provides an ordering point for preparation of the block device named by the unit instance.
+blockdev@.target	system	Represents a particular block device becoming ready for use. Mounts and other units that need the disk can wait for this target instead of starting before the device has been prepared.
 bluetooth.service	system	Runs the BlueZ daemon, which manages Bluetooth adapters, pairing, devices, and connections. Desktop settings and applications control Bluetooth through its D-Bus interfaces.
 bluetooth.target	both	Groups units needed to provide Bluetooth support.
 bolt.service	system	Manages authorization and enrollment of Thunderbolt devices such as docks and external GPUs. Desktop settings use its D-Bus API to approve devices on systems with Thunderbolt security enabled.
-boot-complete.target	system	Marks a boot as successfully completed after any configured boot-health checks have passed.
+boot-complete.target	system	Marks a boot as successfully completed after any configured boot-health checks have passed. Boot-tracking components can use it to clear failure counters that would otherwise trigger recovery or a fallback boot.
+brltty-udev.service	system	Runs BRLTTY when braille hardware is discovered through udev. It connects supported refreshable braille displays to Linux console screen content and input.
+brltty.service	system	Runs BRLTTY to provide access to Linux consoles through a refreshable braille display. It detects supported braille devices and translates screen contents and braille-key input.
 chrony-wait.service	system	Waits for chronyd to synchronize the system clock before allowing time-dependent units to proceed. Units that require an accurate clock can order themselves after it.
-chrony.service	system	Runs chronyd to synchronize the system clock with NTP servers. Chronyd continuously estimates clock drift and corrects the local time while the machine is running.
-chronyd.service	system	Runs chronyd to synchronize the system clock with NTP servers and, when configured, provide time to other machines. It continuously estimates clock drift and corrects the local time.
+chrony.service	system	Runs chronyd to synchronize the system clock with NTP servers. It keeps time accurate despite hardware-clock drift, suspend and resume, or intermittent network access.
+chronyd.service	system	Runs chronyd to synchronize the system clock with NTP servers and, when configured, provide time to other machines. It keeps time accurate despite hardware-clock drift, suspend and resume, or intermittent network access.
 cloud-config.service	system	Runs cloud-init's configuration stage after networking is available. Its modules handle settings such as locale, package sources, and SSH configuration supplied by the cloud data source.
-cloud-config.target	system	Marks cloud-init's configuration stage as available to dependent units.
+cloud-config.target	system	Marks cloud-init's main configuration stage as complete. Services that need the cloud provider's instance settings can wait for this target before starting.
 cloud-final.service	system	Runs cloud-init's final modules after networking and most system services are available. These include package installation, configuration-management integrations, and user-provided startup scripts.
 cloud-init-local.service	system	Runs cloud-init's early local stage before networking is configured. It discovers the instance data source and can apply network configuration needed for later stages.
 cloud-init.service	system	Runs cloud-init modules that require configured networking and consume network-provided instance metadata. It applies the instance's main initialization configuration before the final cloud-init stage.
-cloud-init.target	system	Groups the cloud-init stages so other units can order themselves after instance initialization.
+cloud-init.target	system	Marks the cloud-init stages as complete. Services can wait for it when they need the cloud VM's users, networking, packages, or startup configuration to be in place.
 colord-session.service	user	Provides color-management services to applications in a desktop user session. It connects session applications with colord's device profiles and color transformations.
 colord.service	system	Stores color profiles and associates them with displays, printers, scanners, and cameras. Desktop applications use its D-Bus API to apply consistent color calibration across devices.
 configure-printer@.service	system	Configures a newly discovered printer for use through CUPS. Each instance creates or updates the local queue for one detected printer.
@@ -57,10 +59,12 @@ console-getty.service	system	Provides a text login prompt on a container or syst
 console-setup.service	system	Applies the configured keyboard layout and font to Linux virtual consoles. This determines how keys and characters behave outside the graphical desktop.
 container-getty@.service	system	Provides a text login prompt on an additional terminal exposed by a container manager. Each instance attaches a getty to one container pseudo-terminal.
 containerd.service	system	Runs the containerd runtime, which manages container images, storage, lifecycle, and low-level runtimes. Higher-level tools such as Docker and Kubernetes ask it to create containers, manage snapshots, and invoke an OCI runtime such as `runc`.
-cron.service	system	Runs commands at scheduled times from system and user crontabs. It wakes at the configured minute, hour, day, and month fields and launches matching jobs.
-crond.service	system	Runs commands at scheduled times from system and user crontabs under Fedora and RHEL-family distributions. It wakes at the configured time fields and launches matching jobs.
-cryptsetup-pre.target	system	Provides an ordering point before local encrypted volumes are unlocked.
-cryptsetup.target	system	Groups local encrypted block devices that must be unlocked during startup.
+cron.service	system	Runs commands at scheduled times from system and user crontabs. This lets recurring maintenance, backups, and other automated tasks run without someone starting them manually.
+crond.service	system	Runs commands at scheduled times from system and user crontabs under Fedora and RHEL-family distributions. This lets recurring maintenance, backups, and other automated tasks run without someone starting them manually.
+cryptdisks-early.service	system	Unlocks encrypted block devices that must be available in the earliest local-filesystem boot stage. It processes the early subset of `/etc/crypttab` before the regular `cryptdisks.service`.
+cryptdisks.service	system	Unlocks encrypted block devices listed in `/etc/crypttab` during boot. It creates decrypted device-mapper devices for filesystems and swap needed later in startup.
+cryptsetup-pre.target	system	Marks the point immediately before local encrypted volumes are unlocked. Services that prepare keys or other prerequisites can arrange to run before this target.
+cryptsetup.target	system	Marks the point when local encrypted block devices needed during startup have been unlocked. Filesystems and other units that use those decrypted devices wait for this target.
 ctrl-alt-del.target	system	Handles a Ctrl+Alt+Delete request, normally by starting a system reboot. Systemd activates this target when it receives the corresponding key sequence or signal.
 cups-browsed.service	system	Discovers shared and driverless IPP printers on the network. It creates and removes local CUPS queues as advertised printers appear and disappear.
 cups.path	system	Watches CUPS's scheduler state file and starts `cups.service` when that file exists. This lets saved scheduler state reactivate the print service through systemd path activation.
@@ -72,31 +76,32 @@ dbus.service	both	Runs the D-Bus message bus used by services and applications i
 dbus.socket	both	Listens for D-Bus connections and activates the configured message-bus service in the corresponding system or user manager.
 dconf.service	user	Provides the dconf settings database used by GNOME and other desktop applications. Applications access shared preferences through this service and are notified when settings change.
 debug-shell.service	system	Starts a root shell on a dedicated virtual terminal for early-boot debugging. Systemd places the unauthenticated shell on the configured debug TTY so startup problems can be inspected directly.
-default.target	both	Names the default collection of units started by a system or user systemd manager.
+default.target	both	Selects what a system or user systemd manager starts by default. On a system it normally points to a text-mode or graphical boot target; in a user manager it starts the normal session services.
 dirmngr.service	user	Handles certificate revocation checks and retrieves keys and certificates from network servers for GnuPG. GnuPG clients use it for keyserver, LDAP, OCSP, and certificate revocation list access.
 dirmngr.socket	user	Accepts GnuPG network-helper requests and activates `dirmngr.service`.
 display-manager.service	system	Starts the configured graphical login manager, such as GDM, SDDM, or LightDM. The manager presents the login screen and launches the selected desktop session after authentication.
+dmesg.service	system	Copies this boot's kernel messages into `/var/log/dmesg` and rotates snapshots from previous boots. Commands such as `dmesg` and `journalctl -k` can read kernel messages directly; this service creates the traditional text file for tools and workflows that expect it.
 dnf-makecache.service	system	Refreshes cached package and repository metadata used by DNF. Its timer starts it periodically so package searches and update checks can use current repository information.
 dnf-makecache.timer	system	Schedules periodic refreshes of DNF package and repository metadata.
 docker.service	system	Runs the Docker daemon, which builds images and creates and manages containers. The Docker CLI and API clients send it requests over its Unix socket or configured network endpoints.
 docker.socket	system	Listens for Docker API requests and activates the Docker daemon on demand.
 dpkg-db-backup.service	system	Creates a backup of the Debian package database. Its timer runs it periodically so package status and metadata can be recovered after database corruption.
 dpkg-db-backup.timer	system	Schedules regular backups of the Debian package database.
-e2scrub@.service	system	Checks an ext-family filesystem's metadata while it remains mounted, using an LVM snapshot when required. Each instance examines one filesystem and reports problems without modifying the live filesystem.
+e2scrub@.service	system	Checks an ext-family filesystem's metadata while it remains mounted, using an LVM snapshot when required. This finds metadata problems without taking the filesystem offline, so any needed repair can be planned.
 e2scrub_all.service	system	Starts online metadata checks for all eligible ext-family filesystems. It discovers suitable mounts and invokes the per-filesystem scrub operation for each one.
 e2scrub_all.timer	system	Periodically schedules online metadata checks for eligible ext-family filesystems.
 e2scrub_fail@.service	system	Reports a failed ext4 online metadata check for the filesystem named by the unit instance. It records the scrub failure so an administrator can investigate and perform an offline repair if needed.
 e2scrub_reap.service	system	Removes stale LVM snapshots left by interrupted ext4 online metadata checks. This reclaims snapshot storage after a scrub fails or is terminated before cleanup.
 emergency.service	system	Starts the minimal emergency shell used to repair a system when normal startup cannot continue. It runs with very few filesystems or supporting services available.
-emergency.target	system	Provides the most minimal recovery environment, with an emergency shell and few other services.
+emergency.target	system	Provides the smallest recovery environment, with an emergency shell and almost no supporting services. It is used when startup cannot safely proceed far enough to reach the fuller rescue environment.
 evolution-addressbook-factory.service	user	Provides contacts and address books to Evolution and other applications using Evolution Data Server. It creates backend processes for local and remote address-book sources requested by clients.
 evolution-calendar-factory.service	user	Provides calendars, tasks, and memos to Evolution and other applications using Evolution Data Server. It creates backend processes for configured local and remote calendar sources.
 evolution-source-registry.service	user	Tracks the accounts and data sources used by Evolution Data Server for mail, calendars, and contacts. Other Evolution Data Server components query it to find each source and its configuration.
-exit.target	both	Stops a user systemd manager or container when reached.
+exit.target	both	Stops a user systemd manager or container and shuts down the services it manages. User logout and container shutdown can use this target to end the managed environment cleanly.
 filter-chain.service	user	Runs PipeWire's filter-chain daemon for configured audio-processing filters. It creates audio nodes from filter graphs such as equalizers, mixers, and channel converters.
-final.target	system	Provides a late shutdown ordering point for services that must run immediately before systemd exits.
+final.target	system	Marks the final stage of shutdown, immediately before systemd exits. Cleanup services that must run after ordinary filesystems and services have stopped can order themselves around this target.
 firewalld.service	system	Manages firewall rules and network zones dynamically through nftables or iptables backends. Network managers and administration tools use its D-Bus API to adjust rules without rebuilding the entire firewall.
-first-boot-complete.target	system	Marks completion of first-boot provisioning and machine initialization.
+first-boot-complete.target	system	Marks completion of setup that should happen only on a machine's first boot. Other units can use it to wait until initial provisioning has created the machine's identity and configuration.
 flatpak-portal.service	user	Mediates Flatpak requests to desktop portals and manages access to portal interfaces. Sandboxed applications reach desktop capabilities such as file choosers and notifications through this service.
 flatpak-session-helper.service	user	Provides Flatpak session services such as application monitoring and permission integration. It tracks sandboxed applications in the desktop session and connects them with Flatpak's permission machinery.
 flatpak-system-helper.service	system	Performs privileged Flatpak installation and repository operations requested by unprivileged clients. The user-facing Flatpak process calls it over D-Bus when changing system-wide installations.
@@ -106,15 +111,17 @@ fstrim.timer	system	Schedules a periodic trim of unused filesystem blocks on sup
 fwupd-refresh.service	system	Downloads current firmware metadata from configured fwupd remotes and refreshes the available-update cache. Desktop software centers and `fwupdmgr` use that cache when showing firmware updates.
 fwupd-refresh.timer	system	Schedules periodic refreshes of firmware metadata.
 fwupd.service	system	Detects supported hardware and stages or installs firmware updates supplied through LVFS and other configured remotes. Desktop software centers and `fwupdmgr` communicate with it over D-Bus to inspect devices and apply updates.
+gamemoded.service	user	Temporarily adjusts system and process settings when a game requests higher performance. It applies settings such as CPU behavior and process priority for the duration of the game, then restores them when the game exits.
 gcr-ssh-agent.service	user	Provides an SSH agent backed by GCR so desktop keyring credentials can be used for SSH authentication. SSH clients contact it through the agent socket when they need a key to sign an authentication request.
 gcr-ssh-agent.socket	user	Listens for SSH-agent clients and activates the GCR-backed SSH agent. The socket path can be used as `SSH_AUTH_SOCK` by programs in the desktop session.
 gdm.service	system	Runs the GNOME Display Manager, which presents the graphical login screen and starts desktop sessions. It authenticates users and launches the selected GNOME or other installed session.
 gdm3.service	system	Runs the Debian and Ubuntu packaging of GNOME Display Manager for graphical logins and desktop sessions. It authenticates users and launches the desktop session selected at the login screen.
 geoclue.service	system	Provides applications with location estimates from configured network and hardware location sources. Desktop applications request location data through its D-Bus API, subject to the configured access policy.
-getty-pre.target	system	Provides an ordering point before text login prompts are started.
-getty-static.service	system	Starts fallback text login prompts on tty2 through tty6 when D-Bus and systemd-logind are unavailable.
-getty.target	system	Groups the system's local text login prompts.
+getty-pre.target	system	Marks the point immediately before text login prompts are started. Services that must prepare consoles can arrange to finish before this target.
+getty-static.service	system	Starts text login prompts on tty2 through tty6 without relying on D-Bus or systemd-logind. This provides local console logins when the usual dynamic console setup is unavailable.
+getty.target	system	Marks the point when the system's local text login prompts have been started. Other units use it to coordinate work that must happen before or alongside console logins.
 getty@.service	system	Provides a text login prompt on a Linux virtual console, with one instance for each console. It runs `agetty`, which reads the login name and hands authentication to the system login program.
+glib-pacrunner.service	user	Evaluates proxy auto-configuration rules for applications using GLib networking. It asks pacrunner which proxy, if any, should handle a requested URL.
 gnome-initial-setup-first-login.service	user	Runs GNOME's first-login setup assistant for an existing user account. It guides the user through initial desktop settings such as language, privacy, and online accounts.
 gnome-keyring-daemon.service	user	Stores passwords, keys, and other secrets for a GNOME user session and performs cryptographic operations with them. Applications use its Secret Service and related interfaces to retrieve credentials without storing them directly.
 gnome-keyring-daemon.socket	user	Accepts requests for GNOME Keyring and activates its daemon in the user session. Clients use this socket to reach the keyring's secret-storage and cryptographic services.
@@ -133,6 +140,7 @@ gpg-agent-extra.socket	user	Provides a restricted secondary socket for forwardin
 gpg-agent-ssh.socket	user	Provides GnuPG's SSH-agent-compatible socket for SSH authentication with managed keys. SSH clients can use it as `SSH_AUTH_SOCK` to sign authentication requests with keys known to GnuPG.
 gpg-agent.service	user	Manages GnuPG private-key operations and caches passphrases for the user session. GnuPG tools delegate signing, decryption, and smart-card access to this process so secret keys remain centralized.
 gpg-agent.socket	user	Accepts standard GnuPG agent requests and activates `gpg-agent.service`. GnuPG clients connect here when they need private-key or passphrase operations.
+gpu-manager.service	system	Detects installed GPUs and graphics-driver changes before the graphical login screen starts. Ubuntu uses this information to select and configure the appropriate graphics drivers, including on systems with multiple GPUs.
 graphical-session-pre.target	user	Groups user services that must start before the graphical session is considered available.
 graphical-session.target	user	Marks the lifetime of the current graphical user session and groups services tied to it. Session services can bind themselves to this target so they stop together at logout.
 graphical.target	system	Starts a multi-user system together with its configured graphical login manager. It is the usual boot target for machines that present a graphical login screen.
@@ -144,40 +152,44 @@ gvfs-gphoto2-volume-monitor.service	user	Detects cameras accessible through gPho
 gvfs-metadata.service	user	Stores per-file metadata such as custom icons and file-manager attributes for GVFS clients. Nautilus and other GIO applications use this database for information that is not stored in the file itself.
 gvfs-mtp-volume-monitor.service	user	Detects phones and media players using the Media Transfer Protocol and exposes them to GVFS applications. This lets GNOME file managers browse and transfer files on compatible USB devices.
 gvfs-udisks2-volume-monitor.service	user	Tracks disks and removable media through UDisks and exposes them to GVFS applications. This is how GNOME file managers notice newly connected drives and present actions such as mounting and ejecting them.
-halt.target	system	Coordinates shutdown and stops the operating system without powering off the machine.
-hibernate.target	system	Coordinates services that prepare for and resume from system hibernation.
+halt.target	system	Coordinates shutdown and stops the operating system without powering off the machine. Unlike `poweroff.target`, it leaves the hardware running after filesystems and services have been shut down.
+hibernate.target	system	Coordinates hibernation, which saves the contents of RAM to disk and powers off the machine. On the next boot, the saved state is restored so applications can continue where they left off.
 httpd.service	system	Runs the Apache HTTP server under its Fedora and RHEL unit name, serving websites and forwarding configured application requests. It listens on configured HTTP and HTTPS endpoints and dispatches requests through Apache modules and virtual hosts.
-hybrid-sleep.target	system	Coordinates a sleep operation that both suspends to RAM and writes the system state to disk.
+hv_kvp_daemon.service	system	Exchanges key-value data between a Linux guest and its Microsoft Hyper-V host. The host uses it to retrieve guest information and provide configuration data through Hyper-V integration services.
+hybrid-sleep.target	system	Coordinates a sleep operation that keeps the system state in RAM and also writes it to disk. The machine can resume quickly like a normal suspend, but can still recover its session if power is lost.
 iio-sensor-proxy.service	system	Reads accelerometers and ambient-light sensors and exposes their data to desktop applications. Desktop environments use its D-Bus interface for features such as automatic screen rotation and brightness adjustment.
-initrd-cleanup.service	system	Stops services in the initial RAM disk after the real root filesystem is ready. This clears initrd-only processes before control is fully transferred to the installed system.
-initrd-fs.target	system	Groups filesystems mounted by the initial RAM disk before switching to the real root.
+initrd-cleanup.service	system	Stops services that were needed only in the initial RAM disk after the real root filesystem is ready. This prevents temporary early-boot processes from continuing to run in the installed system.
+initrd-fs.target	system	Groups filesystems that the initial RAM disk must mount before switching to the real root filesystem. This includes storage needed to locate or assemble the installed system during early boot.
 initrd-parse-etc.service	system	Reads mount configuration from the real root filesystem while still running in the initial RAM disk. It uses that configuration to generate the filesystem and swap units needed before switching root.
-initrd-root-device.target	system	Marks the root block device as available inside the initial RAM disk.
-initrd-root-fs.target	system	Marks the real root filesystem as mounted and ready inside the initial RAM disk.
+initrd-root-device.target	system	Marks the block device containing the real root filesystem as available inside the initial RAM disk. Early-boot units use this point to wait until the installed system can be mounted.
+initrd-root-fs.target	system	Marks the real root filesystem as mounted and ready inside the initial RAM disk. Units that prepare the installed system can wait for this point before the switch away from the temporary boot environment.
 initrd-switch-root.service	system	Switches from the initial RAM disk to the real root filesystem and starts its system manager. This is the handoff from the temporary early-boot environment to the installed operating system.
 initrd-switch-root.target	system	Coordinates the transition from the initial RAM disk to the real root filesystem.
-initrd-udevadm-cleanup-db.service	system	Removes udev database state that should not be carried from the initial RAM disk into the real system. The real system's udev manager can then rebuild device state for its own runtime environment.
+initrd-udevadm-cleanup-db.service	system	Removes temporary udev device records created in the initial RAM disk before switching to the real system. This keeps early-boot state from being mistaken for the real system's current device state.
 initrd-usr-fs.target	system	Marks a separate `/usr` filesystem as available during initial-RAM-disk startup.
 initrd.target	system	Groups the normal startup units used within the initial RAM disk.
+integritysetup-pre.target	system	Provides a point for services that must finish before local integrity-protected volumes are activated. Volume setup waits for this target before configuring dm-integrity devices.
+integritysetup.target	system	Groups local block devices protected with dm-integrity that are activated during startup.
 ipp-usb.service	system	Exposes compatible USB printers as network-style IPP devices for driverless printing. Print clients discover the locally proxied device and communicate with it using the same IPP protocols used by network printers.
-irqbalance.service	system	Distributes hardware interrupt handling across processors to balance CPU load. It periodically adjusts IRQ affinities so interrupt-heavy devices do not unnecessarily concentrate work on one CPU.
+irqbalance.service	system	Distributes hardware interrupt handling across processors instead of leaving it concentrated on a few CPUs. This can improve responsiveness and throughput on systems where busy devices generate many interrupts.
 iscsid.service	system	Maintains iSCSI sessions and handles authentication and connection recovery for network block devices. iSCSI management tools use it to log in to remote storage targets and keep their connections alive.
 iscsid.socket	system	Accepts iSCSI management requests and activates the iSCSI daemon. Local iSCSI tools connect to this socket when they need session-management work from `iscsid.service`.
 kerneloops.service	system	Collects kernel oops reports from the system log and submits them to kerneloops.org. These reports describe recoverable kernel faults and help kernel developers identify recurring failures.
-kexec.target	system	Coordinates shutdown before booting directly into another kernel with `kexec`.
+kexec.target	system	Coordinates shutdown before booting directly into another kernel with `kexec`. This skips the firmware and hardware initialization of a full reboot, which is useful for fast restarts and some crash-recovery setups.
+keyboard-setup.service	system	Configures the keyboard layout used by Linux text consoles early in boot. This makes console login and recovery prompts use the configured key mapping rather than the kernel's default layout.
 keyboxd.service	user	Stores and searches GnuPG public keys on behalf of GnuPG clients. It centralizes access to the user's key database for operations such as importing keys and finding encryption recipients.
 keyboxd.socket	user	Accepts GnuPG public-key database requests and activates `keyboxd.service`. GnuPG clients connect here to query or update the shared key database.
-kmod-static-nodes.service	system	Creates static device nodes required by installed kernel modules early in boot. It derives the list from module metadata before dynamic device discovery is fully available.
+kmod-static-nodes.service	system	Creates `/dev` entries that installed kernel modules declare they need. It runs before normal hardware discovery is fully available so early boot services can access those devices.
 ldconfig.service	system	Rebuilds the dynamic linker's shared-library cache after system files change. The cache maps library names to installed files so dynamically linked programs can locate their dependencies efficiently.
 libvirtd.service	system	Runs the libvirt daemon, which manages virtual machines and their networks and storage. Tools such as `virsh` and graphical virtualization managers use its API to define, start, and inspect guests.
 libvirtd.socket	system	Accepts local libvirt management connections and activates the daemon. Libvirt clients connect to this socket to manage virtual machines, networks, and storage pools.
 lightdm.service	system	Runs the LightDM graphical login screen and starts desktop sessions. It authenticates users and launches the desktop environment selected at login.
 local-fs-pre.target	system	Provides an ordering point before local filesystems are checked and mounted.
-local-fs.target	system	Groups local filesystems that must be mounted during startup.
+local-fs.target	system	Marks the point when local filesystems needed during startup have been mounted. Services that need data outside the root filesystem can wait for this target before accessing it.
 logrotate.service	system	Rotates, compresses, and removes old log files according to logrotate configuration. Rotation keeps actively written logs bounded while retaining the configured number of older copies.
 logrotate.timer	system	Schedules regular log-file rotation. Each activation starts `logrotate.service` to process the system's configured log policies.
 machine.slice	system	Groups virtual machines and containers registered with systemd for resource accounting and control. Resource limits applied to this slice affect the machine workloads beneath it.
-machines.target	system	Groups services that manage local virtual machines and system containers. Machine-management services can join this target so their startup and shutdown are coordinated.
+machines.target	system	Groups services that manage local virtual machines and system containers. This gives systemd a common point for starting or stopping machine-management services together.
 man-db.service	system	Updates the index used by `man -k` and `apropos` to search installed manual pages. It scans installed manuals and records their names and short descriptions in the search database.
 man-db.timer	system	Schedules regular updates of the manual-page search index. Each activation starts `man-db.service` so newly installed or removed manuals are reflected in searches.
 modprobe@.service	system	Loads the kernel module named by the unit instance. Other units can depend on an instance when they require a particular kernel driver or subsystem.
@@ -196,10 +208,12 @@ nfs-server.service	system	Starts the kernel NFS server and exports configured fi
 nfs-utils.service	system	Acts as a common restart point for NFS client and server daemons from the nfs-utils package. Restarting it also restarts the active NFS services grouped beneath it.
 nftables.service	system	Loads the system's nftables firewall rules into the kernel. It applies the configured ruleset during startup so packets are filtered, translated, or classified as specified.
 nginx.service	system	Runs the nginx web server and reverse proxy. It listens on configured HTTP and HTTPS endpoints and either serves files directly or forwards requests to application servers.
+nm-priv-helper.service	system	Performs privileged network operations on behalf of NetworkManager. Keeping these operations in a small helper lets the main NetworkManager process run with fewer system privileges.
 nmbd.service	system	Provides NetBIOS name service and network browsing for Samba clients and servers. It answers legacy NetBIOS name queries and advertises browse information on local networks.
 nscd.service	system	Caches name-service lookups for users, groups, hosts, and other NSS databases. Programs using the system Name Service Switch can reuse cached answers instead of repeatedly querying files or network identity sources.
-nss-lookup.target	system	Groups services that provide host and network-name lookup through the Name Service Switch.
-nss-user-lookup.target	system	Groups services that provide user and group lookup through the Name Service Switch.
+nslcd.service	system	Runs the Name Service LDAP connection daemon. It lets NSS and PAM look up users, groups, and authentication information in an LDAP directory through a local socket.
+nss-lookup.target	system	Groups services that provide host and network-name lookup through the Name Service Switch. Services can wait for this target when they need configured name sources such as DNS to be available.
+nss-user-lookup.target	system	Groups services that provide user and group lookup through the Name Service Switch. Services can wait for it when startup depends on accounts supplied by sources such as LDAP or systemd-userdb.
 ntp.service	system	Synchronizes the system clock with network time servers using the ntpd daemon. It exchanges NTP packets with the servers and peers configured in `ntp.conf`.
 ntpd.service	system	Synchronizes the system clock with network time servers and can serve time to other machines. It exchanges NTP packets with the servers, peers, and clients allowed by its configuration.
 obex.service	user	Provides Bluetooth file transfer and object exchange through the BlueZ OBEX daemon. Desktop Bluetooth tools use it to send, receive, and browse files on paired devices.
@@ -223,15 +237,18 @@ org.gnome.SettingsDaemon.UsbProtection.service	user	Enforces GNOME's policy for 
 org.gnome.SettingsDaemon.Wacom.service	user	Applies GNOME settings for Wacom tablets, styli, and pad buttons. It configures mappings, pressure behavior, and button actions as supported devices appear.
 org.gnome.SettingsDaemon.XSettings.service	user	Publishes GNOME appearance and toolkit settings to X11 applications through XSettings. This keeps themes, fonts, scaling, and related preferences consistent with the GNOME session.
 org.gnome.Shell@.service	user	Runs GNOME Shell, the desktop shell and Wayland compositor, for a named session. It draws the desktop interface, manages windows, and coordinates session features such as notifications and the overview.
+ovsdb-server.service	system	Runs the Open vSwitch database server. It stores switch, port, controller, and related configuration that Open vSwitch daemons and management tools read and update.
 packagekit-offline-update.service	system	Applies package updates in a dedicated offline boot environment before the normal system starts. PackageKit stages the transaction beforehand, and this service records its result for the desktop update tool.
 packagekit.service	system	Provides a distribution-neutral package-management API used by graphical software and update tools. It translates requests to the system's native package manager and reports transaction progress over D-Bus.
 pam_namespace.service	system	Creates per-user or per-session filesystem namespaces configured through PAM. Login sessions use these namespaces to give users private views of selected directories.
-paths.target	both	Groups path-watching units active in the current systemd manager.
+paths.target	both	Groups path-watching units active in the current systemd manager. These units monitor files or directories and start services when the configured filesystem changes occur.
 pipewire-media-session.service	user	Runs PipeWire's original session manager, configuring devices and connecting audio and video streams. It applies policy when applications request streams or audio and video hardware appears.
 pipewire-pulse.service	user	Provides a PulseAudio-compatible server backed by PipeWire for applications using the PulseAudio protocol. Existing PulseAudio clients connect to it while PipeWire performs the underlying routing and device access.
 pipewire-pulse.socket	user	Listens for PulseAudio client connections and activates PipeWire's compatibility server.
 pipewire.service	user	Runs the per-user PipeWire media server that routes audio and video streams between applications and devices. A session manager such as WirePlumber supplies policy, while clients use PipeWire for low-latency media and screen capture.
 pipewire.socket	user	Listens for PipeWire client connections and activates the per-user media server.
+pk-debconf-helper.service	user	Relays Debian package-configuration questions from PackageKit to the desktop session. It allows graphical package operations to collect answers for packages that use debconf prompts.
+pk-debconf-helper.socket	user	Listens for PackageKit's debconf communication and activates `pk-debconf-helper.service` when a package needs configuration input.
 plasma-kded.service	user	Runs KDE's per-user service daemon, loading desktop modules for device, settings, and session integration. Its modules provide background features such as removable-device handling and reacting to configuration changes.
 plymouth-quit-wait.service	system	Waits for the graphical boot splash to finish before the display manager starts. This prevents the login screen from competing with Plymouth while it releases the display.
 plymouth-quit.service	system	Stops the Plymouth graphical boot splash when startup is complete. It returns control of the display to the login screen or console.
@@ -241,8 +258,9 @@ podman.socket	system	Listens for Podman API clients and activates the Podman ser
 polkit.service	system	Evaluates authorization rules for privileged operations and coordinates authentication prompts for applications. System services consult it over D-Bus when an unprivileged user requests an action that needs additional authority.
 power-profiles-daemon.service	system	Exposes power-saver, balanced, and performance profiles and applies the selected platform power settings. Desktop power controls use its D-Bus API to show and change the active profile.
 poweroff.target	system	Coordinates shutdown and powers off the machine.
-printer.target	both	Groups units associated with printer hardware and printing services.
+printer.target	both	Groups units associated with printer hardware and printing services. Device management activates it when a printer appears so print-related services can start in response.
 proc-sys-fs-binfmt_misc.automount	system	Mounts the kernel's `binfmt_misc` interface on first access so executable-format handlers can be registered.
+procps.service	system	Applies kernel parameter settings from sysctl configuration during boot. It is the procps package's compatibility unit for configuring values exposed through `/proc/sys`.
 pulseaudio.service	user	Runs the per-user PulseAudio sound server, routing audio streams between applications and devices. It mixes playback, captures microphone input, and exposes per-application volume controls to the desktop.
 pulseaudio.socket	user	Listens for PulseAudio client connections and activates the per-user sound server.
 qemu-guest-agent.service	system	Exchanges status and control messages between a QEMU virtual machine and its host. Management software uses the agent to query guest state and request operations such as filesystem freezing or orderly shutdown.
@@ -250,19 +268,20 @@ qemu-kvm.service	system	Prepares kernel modules and host settings used to run QE
 quotaon.service	system	Enables configured filesystem disk quotas during boot. Once active, the kernel tracks and enforces the user, group, or project limits stored on each filesystem.
 rc-local.service	system	Runs commands from `/etc/rc.local` late in boot for compatibility with older startup setups. It provides a systemd entry point for locally configured commands written for the traditional rc.local mechanism.
 reboot.target	system	Coordinates shutdown and reboots the machine.
-remote-cryptsetup.target	system	Groups encrypted block devices required by remote filesystems.
+remote-cryptsetup.target	system	Groups encrypted block devices that must be unlocked before remote filesystems can be mounted. Remote mount units use it to pull in and wait for their encrypted storage dependencies.
 remote-fs-pre.target	system	Provides an ordering point before remote filesystems are mounted.
-remote-fs.target	system	Groups network and other remote filesystems mounted during startup.
-remote-veritysetup.target	system	Groups integrity-verified block devices required by remote filesystems.
+remote-fs.target	system	Marks the point when network and other remote filesystems needed during startup have been mounted. Services can wait for this target before accessing data provided by servers such as NFS or SMB hosts.
+remote-veritysetup.target	system	Groups integrity-verified block devices required by remote filesystems. Remote mount units use it to wait until dm-verity has verified and exposed their backing storage.
 rescue.service	system	Starts a single-user recovery shell with the basic local filesystems mounted. An administrator can use the shell to repair configuration or storage problems without starting the normal service set.
 rescue.target	system	Provides a single-user recovery environment with basic system services and local filesystems. It brings up `rescue.service` and the minimal dependencies needed for an administrative shell.
 rpc-gssd.service	system	Handles Kerberos authentication for NFS clients using RPCSEC_GSS. It obtains credentials and creates the security contexts used to authenticate requests to protected NFS exports.
 rpc-statd-notify.service	system	Notifies NFS peers after a reboot so interrupted file locks can be recovered. It sends the local host's new status-monitor state to machines recorded before shutdown or failure.
 rpc-statd.service	system	Tracks NFSv2 and NFSv3 file locks and coordinates lock recovery after crashes. NFS locking services register peers with it so both sides can reclaim locks after either machine restarts.
 rpc-svcgssd.service	system	Handles Kerberos authentication for the NFS server using RPCSEC_GSS. It establishes security contexts that let the server verify clients accessing Kerberos-protected exports.
+rpc_pipefs.target	system	Represents the availability of the RPC pipe filesystem used by Linux NFS services. Kernel and userspace NFS components use this filesystem to exchange upcalls and authentication data.
 rpcbind.service	system	Maps ONC RPC program numbers to the network ports used by services such as NFS. RPC clients query it to discover where a requested server program is listening.
 rpcbind.socket	system	Listens for RPC port-mapping requests and activates `rpcbind.service`.
-rpcbind.target	system	Groups the RPC port-mapping service and its dependencies.
+rpcbind.target	system	Groups the RPC port-mapping service and its dependencies. Services using ONC RPC, including older NFS versions, use this target to ensure clients can discover their network ports.
 rsync.service	system	Runs rsync as a network daemon for configured file-transfer modules. Remote clients connect to those named modules to list, upload, or download files according to their access rules.
 rsyslog.service	system	Collects syslog messages and routes them to text files, remote log servers, or other configured destinations. It receives records from local applications and sockets, then filters and formats them according to `rsyslog.conf`.
 rtkit-daemon.service	system	Grants controlled real-time scheduling priority to audio and other latency-sensitive user processes. Clients such as sound servers request priority over D-Bus, and RTKit applies policy and resource limits before granting it.
@@ -273,27 +292,32 @@ runlevel3.target	system	Provides the SysV-compatible alias for the non-graphical
 runlevel4.target	system	Provides a SysV-compatible alias for a distribution-defined multi-user target.
 runlevel5.target	system	Provides the SysV-compatible alias for the graphical target.
 runlevel6.target	system	Provides the SysV-compatible alias for the reboot target.
+rygel.service	user	Runs Rygel, a UPnP and DLNA media server for the user's session. It advertises configured music, photos, and videos to compatible players and televisions on the local network.
 samba-ad-dc.service	system	Runs Samba as an Active Directory domain controller, providing directory, authentication, DNS, and file services. Windows and Samba clients use it to join the domain, authenticate users, and discover domain resources.
 saned.socket	system	Listens for network scanner requests and activates a SANE server instance.
 saned@.service	system	Serves a network scanner client using the SANE scanning interface. A socket-activated instance accesses locally configured scanner hardware and returns image data to the remote client.
 sddm.service	system	Runs the SDDM graphical login screen and starts desktop sessions, commonly for KDE Plasma. It authenticates the selected user and launches the requested X11 or Wayland session.
+secureboot-db.service	system	Applies packaged updates to the UEFI Secure Boot signature database and revocation list. It uses `sbkeysync` to synchronize approved and revoked keys with the firmware databases.
 serial-getty@.service	system	Provides a login prompt on a serial console, with one instance for each serial device. It lets a user authenticate through a physical serial port or a virtual machine's serial console.
-session.slice	user	Groups the core services of a user's login session for resource management. systemd places these processes in a shared cgroup hierarchy for accounting and resource controls.
+session.slice	user	Groups the processes belonging to a user's login sessions for resource management. Limits applied to this slice affect interactive sessions collectively without including the user's background services and applications.
+setvtrgb.service	system	Loads the color palette used by Linux virtual consoles. It applies the colors configured in `/etc/vtrgb` during boot.
 shutdown.target	both	Coordinates the ordered stopping of services and unmounting of filesystems during shutdown.
-sigpwr.target	system	Handles a power-failure signal reported by the kernel or an uninterruptible power supply.
+sigpwr.target	system	Provides a place for services to respond when systemd receives a power-failure signal from the kernel or an uninterruptible power supply. Administrators can attach units that save state or begin an orderly shutdown.
 sleep.target	system	Groups services that prepare for and resume from any system sleep operation.
-slices.target	system	Groups the slice units that define systemd's control-group hierarchy.
-smartcard.target	both	Groups units associated with smart-card hardware and services.
+slices.target	system	Groups the slice units that define systemd's control-group hierarchy. Slices divide services and sessions into branches where CPU, memory, and other resource limits can be accounted for or applied together.
+smartcard.target	both	Groups units associated with smart-card hardware and services. Device management activates it when a smart-card reader appears so authentication and card-management services can respond.
 smb.service	system	Provides SMB file and printer sharing through Samba. Network clients use the SMB protocol to access the shares and printers defined in the Samba configuration.
 smbd.service	system	Serves SMB file and printer shares to Windows, macOS, and Linux clients through Samba. It handles authenticated client sessions and performs file operations against the configured local paths.
 snapd.apparmor.service	system	Loads and updates AppArmor profiles generated for installed snap packages. These profiles enforce the filesystem, device, and interface restrictions declared by each snap.
 snapd.seeded.service	system	Marks completion of snapd's initial installation of preseeded snaps and assertions. Other boot work can use this marker to wait until the image's bundled snap state has been imported.
 snapd.service	system	Installs, updates, removes, and launches snap packages and manages their system integration. The `snap` client and desktop tools send requests to its local API, while snapd handles downloads, mounts, and refresh scheduling.
 snapd.socket	system	Listens for snap client API requests and activates the snapd daemon.
-sockets.target	both	Groups socket-listening units active in the current systemd manager.
-sound.target	both	Groups units associated with detected sound hardware.
+sockets.target	both	Groups socket-listening units active in the current systemd manager. Bringing listeners up early lets client requests activate their corresponding services on demand.
+sound.target	both	Groups units associated with sound hardware. Device management activates it when an audio device appears so sound-related services can start in response.
 speech-dispatcher.service	both	Provides a shared interface through which applications send text to speech synthesizers. Accessibility tools submit text and speech settings to it, and it routes the request to the configured synthesizer backend.
 speech-dispatcher.socket	user	Listens for speech-synthesis client connections and activates Speech Dispatcher.
+speech-dispatcherd.service	system	Runs the system-wide Speech Dispatcher daemon, which provides a shared interface to speech synthesizers. Accessibility clients submit text and speech settings to it, and it routes each request to the configured backend.
+spice-vdagent.service	user	Runs the per-session SPICE guest agent inside a virtual machine. It handles desktop integration such as clipboard sharing and automatic display resizing and exchanges messages with the system SPICE agent daemon.
 spice-vdagentd.service	system	Coordinates clipboard, display resizing, and other desktop integration between SPICE virtual-machine guests and hosts. It relays messages between the host's SPICE client and the per-session guest agent.
 spice-vdagentd.socket	system	Listens for SPICE guest-agent connections and activates its system daemon.
 ssh-agent.service	user	Holds decrypted SSH private keys and performs authentication operations for the user session. SSH clients ask the agent to sign authentication challenges without reading the private keys themselves.
@@ -304,9 +328,13 @@ sshd-keygen.target	system	Groups the tasks that generate missing OpenSSH server 
 sshd-keygen@.service	system	Generates one type of OpenSSH server host key, selected by the unit instance. Separate instances create algorithms such as RSA, ECDSA, or Ed25519 before the server starts.
 sshd.service	system	Runs the OpenSSH server and accepts incoming secure shell and file-transfer connections. It authenticates remote users and starts their shell, command, SFTP, or forwarding session.
 sshd.socket	system	Listens for incoming SSH connections and activates the OpenSSH server on demand.
-suspend-then-hibernate.target	system	Coordinates a sleep operation that suspends first and hibernates after a configured delay.
+ssl-cert.service	system	Generates Debian's default self-signed snakeoil TLS certificate and private key. Packages can use this pair as an initial local certificate when no site-specific certificate has been configured.
+storage-target-mode.target	system	Boots the machine into a mode that exposes local block devices over NVMe over TCP. It brings up networking and `systemd-storagetm.service` instead of the normal multi-user service set.
+stunnel4.service	system	Runs configured stunnel instances, which wrap ordinary TCP connections in TLS. It lets clients or servers gain encrypted transport without implementing TLS themselves.
+stunnel@.service	system	Runs one named stunnel configuration as a systemd template instance. Each instance wraps its configured TCP service or client connection in TLS.
+suspend-then-hibernate.target	system	Coordinates a sleep operation that initially keeps the system state in RAM for a quick resume, then writes it to disk and powers down after a delay. This preserves the session if the machine remains asleep long enough to drain its battery.
 suspend.target	system	Coordinates services that prepare for and resume from suspend-to-RAM.
-swap.target	system	Groups swap devices and swap files activated during startup.
+swap.target	system	Marks the point when swap devices and swap files requested during startup are active. Swap gives the kernel disk-backed space for less-used memory pages and, on some systems, stores the hibernation image.
 switcheroo-control.service	system	Exposes GPU information and controls used to launch applications on a selected GPU in hybrid-graphics systems. Desktop environments use its D-Bus API to offer choices such as integrated or discrete graphics when starting an application.
 sysinit.target	system	Groups early system initialization such as mounts, swap, device setup, and kernel configuration. Most ordinary services start only after this foundational boot work has completed.
 syslog.socket	system	Receives local syslog messages and passes them to the configured logging service. Its stable socket path lets applications emit logs before a particular syslog daemon has started.
@@ -314,8 +342,9 @@ sysstat-collect.service	system	Collects a snapshot of system performance counter
 sysstat-collect.timer	system	Schedules regular collection of sysstat performance counters. Each timer firing starts `sysstat-collect.service` to add another sample to the daily history.
 sysstat-summary.service	system	Generates a daily summary from collected sysstat performance data. It processes the previous day's activity file into the report used by sysstat's summary tooling.
 sysstat-summary.timer	system	Schedules generation of the daily sysstat summary. It starts `sysstat-summary.service` once per day after the collection period closes.
+sysstat.service	system	Initializes the system activity logs maintained by sysstat at boot. Later collection jobs append CPU, memory, disk, and other performance statistics for tools such as `sar`.
 system-getty.slice	system	Groups processes belonging to local text-console login prompts. The slice lets systemd account for and limit their resources as a group.
-system-modprobe.slice	system	Groups kernel-module loading jobs started from systemd templates. These short-lived jobs run when another unit requests a particular module.
+system-modprobe.slice	system	Groups jobs that load kernel modules requested by other systemd units. Keeping these short-lived jobs in their own slice lets systemd account for and limit the resources used while adding kernel features or hardware drivers.
 system-update-cleanup.service	system	Removes the marker that requested an offline system update after the update finishes. This returns the next boot to the normal default target.
 system-update-pre.target	system	Groups preparation performed immediately before an offline system update. Update implementations can order setup work before this target is reached.
 system-update.target	system	Boots into the restricted environment used to install an offline system update. Package managers redirect a reboot here after staging updates that must run without the normal system active.
@@ -327,10 +356,12 @@ systemd-ask-password-plymouth.service	system	Forwards pending boot-time password
 systemd-ask-password-wall.path	system	Watches for boot-time password requests that should be broadcast to logged-in terminals. It activates the wall-based prompt helper when a request appears.
 systemd-ask-password-wall.service	system	Broadcasts pending system password prompts to logged-in terminal users. Replies are returned to the service waiting for the credential.
 systemd-backlight@.service	system	Saves and restores the brightness of a display backlight or LED device across boots. Each instance corresponds to one brightness device exposed by the kernel.
+systemd-battery-check.service	system	Checks for external power and sufficient battery charge during early boot. It stops the boot and powers off when charge is critically low and no external supply is connected.
 systemd-binfmt.service	system	Registers handlers for additional executable formats with the kernel's `binfmt_misc` interface. Rules from `binfmt.d` can launch interpreters for formats such as foreign binaries or bytecode.
 systemd-bless-boot.service	system	Marks the current boot as successful for systemd-boot's boot-attempt counting. A successful mark prevents the boot loader from falling back after the configured number of failed attempts.
 systemd-boot-check-no-failures.service	system	Checks whether the system booted without failed units before marking the boot successful. It participates in systemd-boot's automatic boot assessment.
 systemd-bsod.service	system	Displays a full-screen emergency message and diagnostic information after a critical boot failure. It gives the user an error summary when the normal interface is unavailable.
+systemd-confext.service	system	Merges system configuration extension images into `/etc` during boot. Configuration extensions provide read-only files layered over the host's configuration without modifying the underlying filesystem.
 systemd-coredump.socket	system	Receives process core dumps and starts systemd's core-dump handler. The socket allows crashes to be captured without keeping a handler process running continuously.
 systemd-coredump@.service	system	Records and processes one process core dump. Depending on `coredump.conf`, it stores the dump externally or in the journal together with process metadata for tools such as `coredumpctl`.
 systemd-exit.service	both	Instructs a per-user or container systemd manager to exit. It is started as the manager's units are shut down and returns an exit status to the process that launched the manager.
@@ -340,10 +371,10 @@ systemd-fsck@.service	system	Checks a filesystem for errors before it is mounted
 systemd-fsckd.service	system	Collects progress reports from filesystem checks and forwards them to the console or boot splash. It combines updates from checks running in parallel into one progress stream.
 systemd-fsckd.socket	system	Receives progress updates from filesystem-checking processes for `systemd-fsckd.service`. Connecting to the socket starts the progress daemon on demand.
 systemd-growfs-root.service	system	Expands the root filesystem to fill its backing block device during boot. This lets a system image automatically consume space added when it is deployed to a larger disk.
-systemd-growfs@.service	system	Expands a configured filesystem to fill its backing block device. Each instance operates on the mount point encoded in its unit name.
+systemd-growfs@.service	system	Expands a configured filesystem to fill its backing block device. This lets a disk image use additional space when it is deployed to a larger disk or its partition is enlarged.
 systemd-halt.service	system	Performs the final userspace steps before halting the machine. It hands control to the kernel after services have stopped and filesystems have been unmounted.
 systemd-hibernate-resume.service	system	Restores a saved system image from a hibernation device during early boot. If a valid image is found, the kernel resumes the previous session instead of continuing a fresh boot.
-systemd-hibernate-resume@.service	system	Restores a saved system image from the hibernation device named by the unit instance. It runs in early boot before filesystems and normal services start.
+systemd-hibernate-resume@.service	system	Restores a saved system image from the hibernation device named by the unit instance. It runs before normal startup so the machine can return to the session that was active when it hibernated.
 systemd-hibernate.service	system	Writes system memory to disk and powers down the machine for hibernation. Sleep hooks and device preparation run before systemd asks the kernel to save the image.
 systemd-hostnamed.service	system	Provides a D-Bus API for reading and changing the machine hostname and related metadata. Tools such as `hostnamectl` and desktop settings panels use this service.
 systemd-hwdb-update.service	system	Rebuilds udev's compiled hardware database from installed device metadata. Udev consults the result to attach model names, capabilities, and other properties to detected hardware.
@@ -352,7 +383,7 @@ systemd-importd.service	system	Imports, exports, and downloads disk images used 
 systemd-initctl.service	system	Provides compatibility for software using the legacy SysV `initctl` interface. It translates supported requests into corresponding systemd operations.
 systemd-initctl.socket	system	Receives requests on the legacy `initctl` interface and activates its compatibility service. This preserves the named-pipe interface expected by older software.
 systemd-journal-catalog-update.service	system	Rebuilds the journal message catalog used to add explanatory text to structured log messages. It runs after packages install or update catalog files.
-systemd-journal-flush.service	system	Flushes journal records from volatile memory storage to persistent disk storage early in boot. This moves messages collected before persistent filesystems were ready into the on-disk journal.
+systemd-journal-flush.service	system	Moves early boot logs from memory into the persistent system journal. Journald starts before filesystems are ready, so this service preserves those messages after the machine shuts down or reboots.
 systemd-journald-audit.socket	system	Receives Linux Audit messages from the kernel for storage in the system journal. It lets `journalctl` show audit records alongside other system logs.
 systemd-journald-dev-log.socket	system	Receives traditional syslog messages sent to `/dev/log` for storage in the journal. Programs using the syslog API write through this socket.
 systemd-journald-varlink@.socket	system	Receives Varlink requests for the journal namespace named by the unit instance. Clients use it to access namespace-specific journal services.
@@ -363,7 +394,7 @@ systemd-journald@.socket	system	Receives journal messages for the journal namesp
 systemd-kexec.service	system	Performs the final operation that starts a kernel previously loaded with `kexec`. It bypasses firmware initialization and the normal boot loader after shutdown has stopped running services.
 systemd-localed.service	system	Provides a D-Bus API for reading and changing system locale and console keyboard settings. `localectl` and desktop settings panels use it to update the corresponding configuration files.
 systemd-logind.service	system	Tracks users, sessions, and seats and handles power keys, lid switches, and device access for logged-in users. Desktop environments and `loginctl` use its D-Bus API to inspect sessions and request suspend, reboot, or shutdown operations.
-systemd-machine-id-commit.service	system	Commits a temporary machine ID to persistent storage once the root filesystem is writable. This preserves the identity generated earlier when `/etc` was read-only or transient.
+systemd-machine-id-commit.service	system	Saves the machine ID generated during early boot once `/etc` becomes writable. System services use this ID to recognize the installation consistently across reboots, even when the root filesystem initially starts read-only.
 systemd-machined.service	system	Tracks local virtual machines and system containers and exposes them through `machinectl` and D-Bus. It records their names, addresses, resource usage, and lifecycle state for management tools.
 systemd-modules-load.service	system	Loads kernel modules named in `modules-load.d` configuration during boot. Packages and administrators use these files for modules that must be present without waiting for hardware-driven loading.
 systemd-network-generator.service	system	Generates systemd-networkd configuration from network settings supplied on the kernel command line. This is used when an initrd or image must bring up networking before ordinary configuration is available.
@@ -371,34 +402,40 @@ systemd-networkd-wait-online.service	system	Waits until systemd-networkd reports
 systemd-networkd-wait-online@.service	system	Waits for a selected network interface managed by systemd-networkd to become configured. Each instance limits the online check to the interface encoded in its name.
 systemd-networkd.service	system	Configures network links, addresses, routes, and related settings from `.network` and `.netdev` files. It also reports link state to other services through D-Bus and its runtime state files.
 systemd-networkd.socket	system	Listens for kernel notifications about links, addresses, and routes and activates `systemd-networkd.service` when they arrive.
-systemd-nspawn@.service	system	Starts the systemd-nspawn container named by the unit instance. Container settings and the matching filesystem image determine its networking, resources, and startup command.
+systemd-nspawn@.service	system	Starts and supervises the systemd-nspawn container named by the unit instance. It runs a lightweight Linux environment from the matching filesystem image with its configured networking and resource limits.
 systemd-oomd.service	system	Monitors cgroup memory pressure and kills selected processes before memory exhaustion makes the system unresponsive. Units opt into its policy through systemd resource-control settings such as `ManagedOOMMemoryPressure`.
 systemd-oomd.socket	system	Accepts registrations for cgroups managed by `systemd-oomd` and activates the daemon. Systemd managers use it to communicate which cgroups and out-of-memory policies should be monitored.
-systemd-pcrmachine.service	system	Measures the machine ID into a TPM platform configuration register as part of measured boot. This contributes the installation's identity to TPM policies used for protected credentials and secrets.
+systemd-pcrmachine.service	system	Records the machine's identity in the TPM as part of measured boot. This lets encrypted credentials and other TPM-protected secrets be tied to this particular operating-system installation.
 systemd-pcrphase-initrd.service	system	Measures the initial-RAM-disk boot phase into a TPM platform configuration register. The marker lets TPM policies distinguish operations performed inside the initrd from later boot phases.
 systemd-pcrphase-sysinit.service	system	Measures the early system-initialization phase into a TPM platform configuration register. TPM policies can use the transition to release secrets only after the real system has begun initialization.
 systemd-pcrphase.service	system	Measures boot-phase transitions into TPM platform configuration registers for measured-boot policies. These markers allow secrets to be bound to particular stages of a trusted boot sequence.
-systemd-portabled.service	system	Attaches and manages portable service images through `portablectl` and D-Bus. It connects an image's unit files to the host while keeping the image's application files self-contained.
+systemd-portabled.service	system	Attaches and manages portable service images through `portablectl` and D-Bus. A portable image bundles an application and its files, while this service makes its systemd units available for the host to start and supervise.
 systemd-poweroff.service	system	Performs the final userspace steps before powering off the machine. It hands control to the kernel after services have stopped and filesystems have been unmounted.
 systemd-pstore.service	system	Archives crash and diagnostic records left by firmware or the kernel in persistent platform storage. It moves records from pstore into the journal and filesystem so they survive subsequent reboots for inspection.
 systemd-quotacheck.service	system	Checks filesystem quota metadata before quotas are enabled. It rebuilds inconsistent usage information so per-user and per-group limits start with accurate accounting.
 systemd-random-seed.service	system	Restores an entropy seed during boot and saves a new seed during shutdown for the kernel random-number generator. Carrying the seed across boots helps the generator initialize securely before other entropy sources are available.
 systemd-reboot.service	system	Performs the final userspace steps before rebooting the machine. It asks the kernel to restart after services have stopped and filesystems have been unmounted.
-systemd-remount-fs.service	system	Remounts the root and kernel API filesystems with their configured options early in boot. This applies `/etc/fstab` settings to filesystems mounted earlier by the kernel or initrd.
+systemd-remount-fs.service	system	Remounts the root and kernel API filesystems using the options in `/etc/fstab`. The kernel or initrd mounts them before that configuration is available, often with the root filesystem read-only.
 systemd-repart.service	system	Creates or grows disk partitions according to repartition configuration, commonly during image-based boot. It lets one generic image adapt its partition layout and filesystems to the disk where it is deployed.
 systemd-resolved.service	system	Provides local DNS resolution, caching, and per-interface DNS routing to applications. Network managers supply DNS servers and search domains, while clients use the stub resolver, NSS, or D-Bus interfaces.
 systemd-rfkill.service	system	Saves and restores the blocked or unblocked state of wireless radios across boots. Each state file corresponds to a kernel rfkill device such as a Wi-Fi or Bluetooth adapter.
 systemd-rfkill.socket	system	Watches the kernel rfkill interface and activates the service that persists radio state. Events arrive when radios appear or their blocked state changes.
+systemd-storagetm.service	system	Exposes local block devices to other machines as NVMe-over-TCP storage. It is used by `storage-target-mode.target` and tracks devices as they appear or disappear.
 systemd-suspend-then-hibernate.service	system	Suspends the machine to RAM and hibernates it later after a configured delay. This provides quick resume for short sleeps while preserving the session on disk for longer ones.
 systemd-suspend.service	system	Performs the kernel operation that suspends the machine to RAM. It runs configured sleep hooks and freezes user sessions before handing control to the kernel.
 systemd-sysctl.service	system	Applies kernel settings from `sysctl.d` configuration during boot. These settings control networking, virtual memory, security behavior, and other kernel subsystems exposed through `/proc/sys`.
 systemd-sysext.service	system	Merges system-extension images into `/usr` and `/opt` using overlay mounts. Extensions can add version-matched system files without modifying the underlying operating-system image.
+systemd-sysupdate-reboot.service	system	Reboots the machine after systemd-sysupdate installs an update that requires one. It is activated by the update workflow rather than performing the update itself.
+systemd-sysupdate-reboot.timer	system	Schedules the reboot step associated with automatic system updates. When it elapses, it starts `systemd-sysupdate-reboot.service`.
+systemd-sysupdate.service	system	Downloads and installs system updates described by `sysupdate.d` transfer definitions. It can update whole images, partitions, or other resources using systemd's image-based update mechanism.
+systemd-sysupdate.timer	system	Schedules automatic checks and installations performed by `systemd-sysupdate.service`.
 systemd-sysusers.service	system	Creates system users and groups declared in `sysusers.d` configuration. Packages and system images use these declarative records instead of running account-creation scripts.
 systemd-time-wait-sync.service	system	Waits until a time-synchronization service reports that the system clock is synchronized. It delays `time-sync.target` for units that require trustworthy wall-clock time.
 systemd-timedated.service	system	Provides a D-Bus API for changing the system clock, time zone, and network-time settings. `timedatectl` and desktop settings panels use it to update time configuration.
 systemd-timesyncd.service	system	Synchronizes the system clock with network time servers using a lightweight SNTP client. It obtains per-link servers from network configuration and reports synchronization state to systemd.
 systemd-tmpfiles-clean.service	both	Removes aged files and directories according to `tmpfiles.d` cleanup rules. System and user managers run it for temporary data within their respective scopes.
 systemd-tmpfiles-clean.timer	both	Schedules regular cleanup of temporary and volatile files. It starts the matching cleanup service in the system or user manager.
+systemd-tmpfiles-setup-dev-early.service	system	Creates the earliest static device nodes and applies permissions declared by `tmpfiles.d`. It runs before the main device-node setup so boot-critical entries under `/dev` are available.
 systemd-tmpfiles-setup-dev.service	system	Creates static device nodes and applies ownership and permissions from `tmpfiles.d` rules. It runs early so required entries under `/dev` exist before dependent services start.
 systemd-tmpfiles-setup.service	both	Creates volatile files and directories and applies ownership and permissions from `tmpfiles.d` rules during manager startup. Packages use these declarations for runtime paths, caches, locks, and other state that may not survive a reboot or logout.
 systemd-tpm2-setup-early.service	system	Creates or loads the TPM2 storage root key early in boot for services that need it. The key becomes the parent for TPM objects created before the normal system is fully initialized.
@@ -414,12 +451,19 @@ systemd-update-utmp.service	system	Records system boot and shutdown events in th
 systemd-user-sessions.service	system	Allows normal user logins after startup and blocks new logins during shutdown. It does this by creating or removing the system's `nologin` marker at the appropriate point in the boot lifecycle.
 systemd-vconsole-setup.service	system	Applies the configured font and keyboard map to a Linux virtual console. It runs when consoles appear so text login prompts use the system's selected layout and display settings.
 systemd-volatile-root.service	system	Makes the root filesystem transient by placing a writable in-memory layer over a read-only root. Changes made during the boot disappear when the machine restarts.
+tailscaled.service	system	Runs the Tailscale node agent that connects the machine to a Tailscale network. It maintains the encrypted network interface, coordinates peers through the control service, and exposes a local socket to the `tailscale` command.
 thermald.service	system	Monitors Intel thermal sensors and adjusts cooling and power controls to keep hardware within temperature limits. It uses platform thermal data to reduce heat before the kernel must apply more severe throttling.
-time-set.target	system	Marks the point when the system clock has been set from a local source and is approximately correct.
-time-sync.target	system	Marks the point when the system clock has been synchronized with an accurate external source.
+time-set.target	system	Marks the point when the system clock has been set from a local source and is approximately correct. Services can wait for this target when badly wrong timestamps would cause problems but full network time synchronization is unnecessary.
+time-sync.target	system	Marks the point when the system clock has been synchronized with an accurate external source. Services that require trustworthy timestamps can order themselves after this target.
 timers.target	both	Groups timer units active in the current systemd manager.
 tlp.service	system	Applies TLP's laptop power-management settings to processors, radios, storage, and other devices. It reapplies the appropriate battery or AC-power profile when the power source changes.
-tmp.mount	system	Mounts the filesystem used for `/tmp` when it is configured as a separate or temporary mount. Other units can order themselves after it before creating temporary files.
+tmp.mount	system	Mounts the filesystem configured for `/tmp`. This makes a separate disk or memory-backed temporary filesystem available before services begin creating temporary files there.
+tpm-udev.path	system	Watches for TPM devices added after the initial device setup. It starts `tpm-udev.service` so their permissions and runtime state are prepared.
+tpm-udev.service	system	Prepares permissions and related state when a TPM device appears after boot. It applies the tmpfiles configuration used to make the newly added device available to the appropriate users and services.
+tracker-miner-fs-3.service	user	Indexes files and their metadata for Tracker, GNOME's desktop search database. It watches configured directories for changes so file searches can return current names, contents, and metadata.
+tracker-writeback-3.service	user	Writes metadata changes from Tracker back into supported files. Applications use it to persist edits such as ratings, tags, and titles in the file's own metadata when possible.
+tracker-xdg-portal-3.service	user	Provides sandboxed applications with controlled access to Tracker's search index through the desktop portal. It mediates search queries so Flatpak applications do not need unrestricted access to the session database.
+ttyd.service	system	Runs ttyd, a web server that exposes a terminal or configured command through a browser. It relays terminal input and output over WebSockets to connected clients.
 udisks2.service	system	Manages disks and removable media and provides mounting, formatting, and inspection operations to desktop applications. File managers and disk utilities use its D-Bus API to handle drives without performing privileged operations themselves.
 ufw.service	system	Loads firewall rules configured through the Uncomplicated Firewall during boot. It translates the saved UFW policy into the packet-filtering rules enforced by the kernel.
 umount.target	system	Coordinates unmounting filesystems and disabling swap during shutdown.
@@ -428,7 +472,7 @@ upower.service	system	Tracks batteries and other power devices and exposes charg
 usb-gadget.target	system	Groups services that configure the machine to act as a USB peripheral through the Linux USB gadget framework. Gadget configurations can expose functions such as networking, storage, or a serial port to a connected host.
 usb_modeswitch@.service	system	Switches a USB mobile-broadband device from storage mode into modem mode when it is connected. Each instance sends the device-specific command needed to reveal its communications interfaces.
 usbmuxd.service	system	Multiplexes connections from applications to iPhones and other iOS devices over USB. Tools for synchronization, development, and file access share the device connection through its local socket.
-user-runtime-dir@.service	system	Creates and removes a user's `/run/user/UID` runtime directory around their login sessions. The directory holds sockets, locks, and other per-user state that should not survive a reboot.
+user-runtime-dir@.service	system	Creates and removes a user's `/run/user/UID` directory around their login sessions. Desktop and command-line programs use it for sockets, locks, and other temporary state shared within that user's session.
 user.slice	system	Groups all logged-in users and their sessions for resource accounting and control. Each user's manager and session scopes are placed beneath this cgroup hierarchy.
 user@.service	system	Runs a per-user systemd manager that starts and supervises the user's session services. Each instance owns units such as PipeWire, desktop portals, and keyring agents for one user and may remain running after logout when lingering is enabled.
 uuidd.service	system	Generates UUIDs for local clients and coordinates time-based UUID generation across processes. Central coordination prevents duplicate timestamp-based UUIDs when many processes request them concurrently.
@@ -438,11 +482,12 @@ veritysetup.target	system	Groups local dm-verity integrity-protected block devic
 whoopsie.path	system	Watches Ubuntu's crash-report directory and starts the report uploader when a report appears. This avoids keeping the uploader running while there is nothing to submit.
 whoopsie.service	system	Uploads collected Ubuntu crash reports to Ubuntu's error-tracking service. It reads reports prepared by Apport and submits the diagnostic fields used to group recurring failures.
 wireplumber.service	user	Runs PipeWire's session manager, discovering devices and deciding how media streams and nodes are connected. It applies policy for default devices, audio profiles, permissions, and routing when hardware or applications change.
+wireplumber@.service	user	Runs a named WirePlumber instance as a PipeWire session manager. The instance applies policy for device discovery, media routing, permissions, and audio profiles.
 wpa_supplicant-nl80211@.service	system	Runs a WPA supplicant instance for a Wi-Fi interface using the kernel's nl80211 driver interface. The instance performs scanning, association, and WPA or 802.1X authentication for that interface.
 wpa_supplicant-wired@.service	system	Runs a WPA supplicant instance for 802.1X authentication on a wired interface. It exchanges EAP credentials with the network before normal traffic is permitted.
 wpa_supplicant.service	system	Handles Wi-Fi authentication and association on behalf of network-management software. NetworkManager and similar clients configure connections through its control or D-Bus interfaces.
 wpa_supplicant@.service	system	Runs a WPA supplicant instance for a named network interface. Each instance handles association and WPA or 802.1X authentication for that interface.
-xdg-desktop-autostart.target	user	Groups desktop applications launched from XDG autostart files for the current user session.
+xdg-desktop-autostart.target	user	Marks the stage when applications from XDG autostart files are launched for the current desktop session. Session services can use it to coordinate work that must happen before or after those background applications start.
 xdg-desktop-portal-gnome.service	user	Implements desktop portal dialogs and GNOME integration for sandboxed applications. It provides GNOME-native interfaces for choosing files, capturing screens, and other mediated desktop operations.
 xdg-desktop-portal-gtk.service	user	Implements GTK file chooser and other desktop portal interfaces for sandboxed applications. The main portal broker selects it when the current desktop requests the GTK backend.
 xdg-desktop-portal-kde.service	user	Implements desktop portal dialogs and KDE Plasma integration for sandboxed applications. It supplies Plasma-native file choosers, screen sharing, and other mediated desktop operations.

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -41,6 +41,7 @@ pub enum Mode {
   Error,
   SignalMenu,
   StatusFilter,
+  UnitExplanation,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -252,6 +253,9 @@ pub struct Home {
   pub menu_item_rects: Vec<(Rect, usize)>,
   /// Area of the action/signal menu popup, as of the most recent render.
   pub menu_popup_rect: Rect,
+  /// Screen rect of the clickable description in the details pane, as of the most recent render.
+  /// `Some` only when the selected unit has a baked-in explanation.
+  pub explanation_button_rect: Option<Rect>,
 }
 
 pub struct MenuItem {
@@ -928,6 +932,10 @@ impl Component for Home {
         KeyCode::Esc | KeyCode::Enter => vec![Action::EnterMode(Mode::ServiceList)],
         _ => vec![],
       },
+      Mode::UnitExplanation => match key.code {
+        KeyCode::Esc | KeyCode::Enter | KeyCode::Char('q') => vec![Action::EnterMode(Mode::ServiceList)],
+        _ => vec![],
+      },
       Mode::Search => match key.code {
         KeyCode::Esc => vec![Action::EnterMode(Mode::ServiceList)],
         KeyCode::Enter => vec![Action::EnterMode(Mode::ActionMenu)],
@@ -1064,7 +1072,7 @@ impl Component for Home {
       };
     }
 
-    if self.mode == Mode::Error {
+    if self.mode == Mode::Error || self.mode == Mode::UnitExplanation {
       return match mouse.kind {
         MouseEventKind::Down(MouseButton::Left) => vec![Action::EnterMode(Mode::ServiceList)],
         _ => vec![],
@@ -1167,9 +1175,11 @@ impl Component for Home {
 
     match mouse.kind {
       MouseEventKind::Moved => {
-        let was_hovering = self.hovered_field(self.mouse_position);
+        let explanation_rect = self.explanation_button_rect;
+        let over_explanation = |p| explanation_rect.map(|r| r.contains(p)).unwrap_or(false);
+        let was_hovering = (self.hovered_field(self.mouse_position), over_explanation(self.mouse_position));
         self.mouse_position = pos;
-        let is_hovering = self.hovered_field(pos);
+        let is_hovering = (self.hovered_field(pos), over_explanation(pos));
         if was_hovering != is_hovering {
           vec![Action::Render]
         } else {
@@ -1205,6 +1215,11 @@ impl Component for Home {
           let text = self.copyable_fields[idx].1.clone();
           self.copy_with_toast(&text);
           return vec![Action::Render];
+        }
+        if let Some(rect) = self.explanation_button_rect {
+          if rect.contains(pos) {
+            return vec![Action::EnterMode(Mode::UnitExplanation)];
+          }
         }
         if self.search_panel.contains(pos) && self.mode == Mode::ServiceList {
           return vec![Action::EnterMode(Mode::Search)];
@@ -1579,9 +1594,11 @@ impl Component for Home {
     let dim = Style::default().add_modifier(Modifier::DIM);
     let mut rows: Vec<(&str, Line)> = vec![];
     let mut stat_rows: Vec<(&str, Line)> = vec![];
+    let mut explanation: Option<&'static str> = None;
 
     if let Some(m) = selected_item {
       rows.push(("Description", Line::from(m.unit.description.as_str())));
+      explanation = crate::unit_descriptions::explain(&m.unit.name, m.unit.scope);
 
       let active_color = match m.unit.activation_state.as_str() {
         "active" => Color::Green,
@@ -1684,18 +1701,6 @@ impl Component for Home {
       rows.push(("Runtime", Line::from(spans)));
     }
 
-    // Size the details panel to its content instead of a fixed height
-    let details_content_height = rows.len().max(stat_rows.len()).max(1) as u16;
-    let right_panel =
-      Layout::new(Direction::Vertical, [Constraint::Length(details_content_height + 2), Constraint::Percentage(100)])
-        .split(right_panel);
-    let details_panel = right_panel[0];
-    let logs_panel = right_panel[1];
-
-    let details_block = Block::default().title("─Details").borders(Borders::ALL).border_type(BorderType::Rounded);
-    let details_inner = details_block.inner(details_panel);
-    f.render_widget(details_block, details_panel);
-
     fn label_width(rows: &[(&str, Line)]) -> u16 {
       rows.iter().map(|(label, _)| label.len() + 2).max().unwrap_or(0) as u16
     }
@@ -1703,6 +1708,18 @@ impl Component for Home {
     fn split_labels_values<'a>(rows: Vec<(&'a str, Line<'a>)>) -> (Vec<Line<'a>>, Vec<Line<'a>>) {
       rows.into_iter().map(|(label, value)| (Line::from(format!("{label}: ")), value)).unzip()
     }
+
+    // Size the details panel to its content instead of a fixed height
+    let grid_height = rows.len().max(stat_rows.len()).max(1) as u16;
+    let right_panel =
+      Layout::new(Direction::Vertical, [Constraint::Length(grid_height + 2), Constraint::Percentage(100)])
+        .split(right_panel);
+    let details_panel = right_panel[0];
+    let logs_panel = right_panel[1];
+
+    let details_block = Block::default().title("─Details").borders(Borders::ALL).border_type(BorderType::Rounded);
+    let details_inner = details_block.inner(details_panel);
+    f.render_widget(details_block, details_panel);
 
     let panes = if two_columns {
       Layout::new(
@@ -1723,10 +1740,19 @@ impl Component for Home {
     // Every details value line (and runtime stat line) is hoverable and click-to-copy. Register
     // each rendered line's rect and text, bolding the hovered one.
     self.copyable_fields.clear();
-    fn register_copyable_fields(values: &mut [Line], pane: Rect, mouse: Position, out: &mut Vec<(Rect, String)>) {
+    fn register_copyable_fields(
+      values: &mut [Line],
+      pane: Rect,
+      mouse: Position,
+      skip: Option<usize>,
+      out: &mut Vec<(Rect, String)>,
+    ) {
       for (i, line) in values.iter_mut().enumerate() {
         if i as u16 >= pane.height {
           break;
+        }
+        if skip == Some(i) {
+          continue;
         }
         let text = line.spans.iter().map(|s| s.content.as_ref()).collect::<String>().trim().to_string();
         if text.is_empty() {
@@ -1741,13 +1767,58 @@ impl Component for Home {
     }
 
     let (labels, mut values) = split_labels_values(rows);
-    register_copyable_fields(&mut values, panes[1], self.mouse_position, &mut self.copyable_fields);
+    self.explanation_button_rect = None;
+    if explanation.is_some() && !values.is_empty() && panes[1].width > 0 {
+      let (separator, hint) = match panes[1].width {
+        1 => ("", "?"),
+        2..=3 => (" ", "?"),
+        _ => (" ", "[?]"),
+      };
+      let hint_width = Line::from(format!("{separator}{hint}")).width() as u16;
+      let description_width = panes[1].width.saturating_sub(hint_width);
+      let description = values[0].spans.iter().map(|s| s.content.as_ref()).collect::<String>();
+
+      fn truncate_to_width(text: &str, width: u16) -> String {
+        if width == 0 {
+          return String::new();
+        }
+        if Line::from(text).width() <= width as usize {
+          return text.to_string();
+        }
+
+        let mut truncated = String::new();
+        let content_width = width.saturating_sub(1) as usize;
+        for ch in text.chars() {
+          truncated.push(ch);
+          if Line::from(truncated.as_str()).width() > content_width {
+            truncated.pop();
+            break;
+          }
+        }
+        truncated.push('…');
+        truncated
+      }
+
+      let description = truncate_to_width(&description, description_width);
+      let button_width = (Line::from(format!("{description}{separator}{hint}")).width() as u16).min(panes[1].width);
+      let button_rect = Rect { x: panes[1].x, y: panes[1].y, width: button_width, height: 1 };
+      let hovered = button_rect.contains(self.mouse_position);
+      let mut hint_style = Style::default().fg(theme.accent).add_modifier(Modifier::UNDERLINED);
+      if hovered {
+        hint_style = hint_style.add_modifier(Modifier::BOLD | Modifier::REVERSED);
+      }
+      values[0] = Line::from(vec![Span::raw(description), Span::raw(separator), Span::styled(hint, hint_style)]);
+      self.explanation_button_rect = Some(button_rect);
+    }
+
+    let explanation_row = self.explanation_button_rect.map(|_| 0);
+    register_copyable_fields(&mut values, panes[1], self.mouse_position, explanation_row, &mut self.copyable_fields);
     f.render_widget(Paragraph::new(labels).alignment(ratatui::layout::Alignment::Right), panes[0]);
     f.render_widget(Paragraph::new(values), panes[1]);
 
     if two_columns {
       let (stat_labels, mut stat_values) = split_labels_values(stat_rows);
-      register_copyable_fields(&mut stat_values, panes[3], self.mouse_position, &mut self.copyable_fields);
+      register_copyable_fields(&mut stat_values, panes[3], self.mouse_position, None, &mut self.copyable_fields);
       f.render_widget(Paragraph::new(stat_labels).alignment(ratatui::layout::Alignment::Right), panes[2]);
       f.render_widget(Paragraph::new(stat_values), panes[3]);
     }
@@ -1926,6 +1997,44 @@ impl Component for Home {
       f.render_widget(paragraph, popup);
     }
 
+    if self.mode == Mode::UnitExplanation {
+      let selected = self.filtered_units.selected();
+      let text = selected.and_then(|s| crate::unit_descriptions::explain(&s.unit.name, s.unit.scope)).unwrap_or("");
+      let title = selected.map(|s| format!("─What is {}?", s.unit.name)).unwrap_or_else(|| "─What is it?".to_string());
+
+      let area = f.area();
+      let popup_width = 64u16.min(area.width.saturating_sub(4)).max(20);
+      let wrapped = word_wrap(text, popup_width.saturating_sub(4) as usize);
+      let disclaimer = word_wrap(
+        "Matched by unit name and scope; locally replaced units may differ.",
+        popup_width.saturating_sub(4) as usize,
+      );
+      // leading blank + text + blank + disclaimer + blank + hint + 2 borders
+      let popup_height = (wrapped.len() as u16 + disclaimer.len() as u16 + 6).min(area.height.saturating_sub(2));
+      let popup = area.centered(Constraint::Length(popup_width), Constraint::Length(popup_height));
+
+      let mut lines = vec![Line::from("")];
+      lines.extend(wrapped.into_iter().map(Line::from));
+      lines.push(Line::from(""));
+      lines.extend(disclaimer.into_iter().map(|line| Line::from(Span::styled(line, dim))));
+      lines.push(Line::from(""));
+      lines.push(Line::from(Span::styled("Press esc to close", dim)));
+
+      let paragraph = Paragraph::new(lines)
+        .block(
+          Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .padding(ratatui::widgets::Padding::horizontal(1)),
+        )
+        .wrap(Wrap { trim: true });
+
+      f.render_widget(Clear, popup);
+      f.render_widget(paragraph, popup);
+    }
+
     let selected_unit_name = match self.filtered_units.selected() {
       Some(s) => &s.unit.name,
       None => "",
@@ -1956,6 +2065,7 @@ impl Component for Home {
       Mode::ActionMenu => Line::from(span("Execute action: <enter> | Close menu: <esc>", theme.primary)),
       Mode::Processing => Line::from(span("Cancel task: <esc>", theme.primary)),
       Mode::Error => Line::from(span("Close menu: <esc>", theme.primary)),
+      Mode::UnitExplanation => Line::from(span("Close: <esc>", theme.primary)),
       Mode::SignalMenu => Line::from(span("Send signal: <enter> | Close menu: <esc>", theme.primary)),
       Mode::StatusFilter => Line::from(span("Toggle: <space> | All: a | None: n | Close: <esc>", theme.primary)),
     };
@@ -2148,6 +2258,30 @@ fn format_bytes(bytes: u64) -> String {
   } else {
     format!("{value:.1}{}", UNITS[unit])
   }
+}
+
+/// Greedy word-wrap to a given column width. Returns one string per visual line. Words longer than
+/// the width are placed on their own line and allowed to overflow (rare for prose). Width is
+/// measured in chars, which matches display width for the plain English these descriptions use.
+fn word_wrap(text: &str, width: usize) -> Vec<String> {
+  let width = width.max(1);
+  let mut lines: Vec<String> = Vec::new();
+  let mut current = String::new();
+  for word in text.split_whitespace() {
+    if current.is_empty() {
+      current.push_str(word);
+    } else if current.chars().count() + 1 + word.chars().count() <= width {
+      current.push(' ');
+      current.push_str(word);
+    } else {
+      lines.push(std::mem::take(&mut current));
+      current.push_str(word);
+    }
+  }
+  if !current.is_empty() {
+    lines.push(current);
+  }
+  lines
 }
 
 fn format_cpu_nsec(nsec: u64) -> String {

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -1768,6 +1768,7 @@ impl Component for Home {
 
     let (labels, mut values) = split_labels_values(rows);
     self.explanation_button_rect = None;
+    let mut explanation_description = None;
     if explanation.is_some() && !values.is_empty() && panes[1].width > 0 {
       let (separator, hint) = match panes[1].width {
         1 => ("", "?"),
@@ -1776,7 +1777,7 @@ impl Component for Home {
       };
       let hint_width = Line::from(format!("{separator}{hint}")).width() as u16;
       let description_width = panes[1].width.saturating_sub(hint_width);
-      let description = values[0].spans.iter().map(|s| s.content.as_ref()).collect::<String>();
+      let full_description = values[0].spans.iter().map(|s| s.content.as_ref()).collect::<String>();
 
       fn truncate_to_width(text: &str, width: u16) -> String {
         if width == 0 {
@@ -1799,9 +1800,12 @@ impl Component for Home {
         truncated
       }
 
-      let description = truncate_to_width(&description, description_width);
-      let button_width = (Line::from(format!("{description}{separator}{hint}")).width() as u16).min(panes[1].width);
-      let button_rect = Rect { x: panes[1].x, y: panes[1].y, width: button_width, height: 1 };
+      let description = truncate_to_width(&full_description, description_width);
+      let description_width = Line::from(description.as_str()).width() as u16;
+      let separator_width = Line::from(separator).width() as u16;
+      let hint_width = Line::from(hint).width() as u16;
+      let button_rect =
+        Rect { x: panes[1].x + description_width + separator_width, y: panes[1].y, width: hint_width, height: 1 };
       let hovered = button_rect.contains(self.mouse_position);
       let mut hint_style = Style::default().fg(theme.accent).add_modifier(Modifier::UNDERLINED);
       if hovered {
@@ -1809,9 +1813,19 @@ impl Component for Home {
       }
       values[0] = Line::from(vec![Span::raw(description), Span::raw(separator), Span::styled(hint, hint_style)]);
       self.explanation_button_rect = Some(button_rect);
+      explanation_description = Some((full_description, description_width));
     }
 
     let explanation_row = self.explanation_button_rect.map(|_| 0);
+    if let Some((description, width)) = explanation_description {
+      if width > 0 {
+        let rect = Rect { x: panes[1].x, y: panes[1].y, width, height: 1 };
+        if rect.contains(self.mouse_position) {
+          values[0].spans[0].style = values[0].spans[0].style.add_modifier(Modifier::BOLD);
+        }
+        self.copyable_fields.push((rect, description));
+      }
+    }
     register_copyable_fields(&mut values, panes[1], self.mouse_position, explanation_row, &mut self.copyable_fields);
     f.render_widget(Paragraph::new(labels).alignment(ratatui::layout::Alignment::Right), panes[0]);
     f.render_widget(Paragraph::new(values), panes[1]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,5 @@ pub mod utils;
 pub mod systemd;
 
 pub mod ssh;
+
+pub mod unit_descriptions;

--- a/src/unit_descriptions.rs
+++ b/src/unit_descriptions.rs
@@ -1,0 +1,105 @@
+//! Baked-in plain-English explanations of common systemd units.
+//!
+//! The database lives in `src/assets/unit-descriptions.tsv` and is compiled into the
+//! binary. Templated instances (`getty@tty1.service`) fall back to their template
+//! entry (`getty@.service`). Entries are scoped to the system or user manager so a
+//! locally defined unit with the same name in the other manager does not match.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use crate::systemd::UnitScope;
+
+static DESCRIPTIONS: LazyLock<HashMap<(&'static str, UnitScope), &'static str>> = LazyLock::new(|| {
+  let mut descriptions = HashMap::new();
+  for line in
+    include_str!("assets/unit-descriptions.tsv").lines().filter(|line| !line.is_empty() && !line.starts_with('#'))
+  {
+    let mut fields = line.splitn(3, '\t');
+    let (Some(unit_name), Some(scope), Some(description)) = (fields.next(), fields.next(), fields.next()) else {
+      continue;
+    };
+    match scope {
+      "system" => {
+        descriptions.insert((unit_name, UnitScope::Global), description);
+      },
+      "user" => {
+        descriptions.insert((unit_name, UnitScope::User), description);
+      },
+      "both" => {
+        descriptions.insert((unit_name, UnitScope::Global), description);
+        descriptions.insert((unit_name, UnitScope::User), description);
+      },
+      _ => {},
+    }
+  }
+  descriptions
+});
+
+/// Look up the baked-in explanation for a unit, if we have one.
+pub fn explain(unit_name: &str, scope: UnitScope) -> Option<&'static str> {
+  if let Some(desc) = DESCRIPTIONS.get(&(unit_name, scope)) {
+    return Some(desc);
+  }
+  // getty@tty1.service -> getty@.service
+  if let (Some(at), Some(dot)) = (unit_name.find('@'), unit_name.rfind('.')) {
+    if at < dot {
+      let template = format!("{}@{}", &unit_name[..at], &unit_name[dot..]);
+      return DESCRIPTIONS.get(&(template.as_str(), scope)).copied();
+    }
+  }
+  None
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn exact_match() {
+    assert!(explain("systemd-journald.service", UnitScope::Global).unwrap().contains("log"));
+  }
+
+  #[test]
+  fn template_instance_falls_back_to_template() {
+    assert_eq!(explain("getty@tty1.service", UnitScope::Global), explain("getty@.service", UnitScope::Global));
+    assert!(explain("getty@tty1.service", UnitScope::Global).is_some());
+  }
+
+  #[test]
+  fn unknown_unit_returns_none() {
+    assert_eq!(explain("no-such-unit.service", UnitScope::Global), None);
+  }
+
+  #[test]
+  fn lookup_respects_scope() {
+    assert!(explain("docker.service", UnitScope::Global).is_some());
+    assert_eq!(explain("docker.service", UnitScope::User), None);
+    assert!(explain("basic.target", UnitScope::Global).is_some());
+    assert!(explain("basic.target", UnitScope::User).is_some());
+  }
+
+  #[test]
+  fn database_parses_fully() {
+    let mut parsed_entries = 0;
+    let mut scoped_keys = std::collections::HashSet::new();
+    for line in include_str!("assets/unit-descriptions.tsv").lines() {
+      if !line.is_empty() && !line.starts_with('#') {
+        let fields = line.split('\t').collect::<Vec<_>>();
+        assert_eq!(fields.len(), 3, "malformed line: {line}");
+        assert!(matches!(fields[1], "system" | "user" | "both"), "invalid scope: {line}");
+        let scopes: &[UnitScope] = match fields[1] {
+          "system" => &[UnitScope::Global],
+          "user" => &[UnitScope::User],
+          "both" => &[UnitScope::Global, UnitScope::User],
+          _ => unreachable!(),
+        };
+        for scope in scopes {
+          assert!(scoped_keys.insert((fields[0], *scope)), "duplicate unit and scope: {line}");
+        }
+        parsed_entries += 1;
+      }
+    }
+    assert!(parsed_entries > 50);
+  }
+}


### PR DESCRIPTION
A lot of  systemd units have names and Description fields that do not tell you much. This adds a baked-in database of plain-English explanations and exposes it through a small [?] link beside the selected unit description:

<img width="1491" height="996" alt="image" src="https://github.com/user-attachments/assets/81f30896-0aad-4df4-8da8-ad2184383bd1" />

The database currently covers 496 common system and user units across Debian, Ubuntu, Fedora, and Rocky Linux. The descriptions focus on what each unit does and, where the name alone is not enough, why the unit exists or what uses its work. Matches include the systemd manager scope and template instances fall back to their template name, which reduces the chance of explaining an unrelated local unit with the same name. The popup still calls out that locally replaced units may differ.

There is also a small harvesting script for finding candidate units on another machine. The explanations are compiled into the binary, so opening one does not perform network access or invoke another process.
