### PR TITLE
Add remote host picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
+ "unicode-width",
  "windows-sys 0.61.2",
 ]
 
@@ -530,6 +531,16 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console 0.16.4",
+ "shell-words",
 ]
 
 [[package]]
@@ -1804,6 +1815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1966,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "dialoguer",
  "directories",
  "futures",
  "fuzzy-matcher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3.28"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 directories = "6.0.0"
+dialoguer = { version = "0.12.0", default-features = false }
 tui-logger = { version = "0.18.1", default-features = false, features = [
   "tracing-support",
 ] }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ sudo ln -s ~/.cargo/bin/systemctl-tui /usr/bin/systemctl-tui
 
 `systemctl-tui --host user@hostname` manages a remote machine over SSH, no remote install needed. Service operations go over a [systemd-stdio-bridge](https://www.freedesktop.org/software/systemd/man/latest/systemd-stdio-bridge.html) D-Bus connection (like `systemctl --host`) and logs come from running `journalctl` on the remote host, all multiplexed over a single SSH connection.
 
+Run `systemctl-tui --remote` to choose from literal `Host` aliases in `~/.ssh/config` or enter a host on the fly. `--host` remains useful when you already know where you want to connect or are launching from a script.
+
 The remote host needs `systemd-stdio-bridge` (part of the core systemd package on all major distros; verified working on systemd 249 and 255, and the flags we use exist back to at least systemd 239) and `journalctl`. Viewing user-scope services requires a running user manager on the remote host (an active session, or lingering enabled via `loginctl enable-linger`). Editing unit files remotely is not supported yet.
 
 ## Help

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,6 @@ pub mod systemd;
 
 pub mod ssh;
 
+pub mod remote_picker;
+
 pub mod unit_descriptions;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use systemctl_tui::{
   app::App,
   components::home::LogOrder,
-  ssh, systemd,
+  remote_picker, ssh, systemd,
   utils::{get_data_dir, initialize_logging, initialize_panic_handler, version},
 };
 
@@ -30,6 +30,9 @@ struct Args {
   /// Manage a remote host over SSH (e.g. user@hostname). Requires systemd-stdio-bridge on the remote host.
   #[clap(long)]
   host: Option<String>,
+  /// Choose a remote host from SSH config
+  #[clap(short, long, conflicts_with = "host")]
+  remote: bool,
   /// Order used to display service logs
   #[clap(long, value_enum, default_value_t = CliLogOrder::NewestFirst)]
   log_order: CliLogOrder,
@@ -104,7 +107,8 @@ async fn main() -> Result<()> {
   };
 
   // Connect before entering the TUI so SSH auth prompts (password, 2FA) work
-  if let Some(host) = args.host {
+  let host = if args.remote { Some(remote_picker::choose_remote_host()?) } else { args.host };
+  if let Some(host) = host {
     println!("Connecting to {host}...");
     if let Err(e) = ssh::init(host) {
       // ssh has already printed its own error to stderr

--- a/src/remote_picker.rs
+++ b/src/remote_picker.rs
@@ -1,0 +1,104 @@
+use std::{collections::HashSet, fs, path::PathBuf};
+
+use anyhow::{bail, Context, Result};
+use dialoguer::{Input, Select};
+
+const MANUAL_ENTRY: &str = "Enter a host manually…";
+
+/// Prompt for a remote host before the main TUI starts.
+pub fn choose_remote_host() -> Result<String> {
+  let mut hosts = ssh_config_hosts();
+  deduplicate(&mut hosts);
+
+  let mut choices = hosts.clone();
+  choices.push(MANUAL_ENTRY.to_string());
+
+  let selection = Select::new()
+    .with_prompt("Remote host")
+    .items(&choices)
+    .default(0)
+    .interact_opt()
+    .context("Failed to read remote host selection")?;
+
+  let Some(selection) = selection else {
+    bail!("Remote host selection cancelled");
+  };
+
+  let host = if selection == hosts.len() {
+    Input::<String>::new()
+      .with_prompt("SSH host")
+      .validate_with(|value: &String| -> std::result::Result<(), &str> {
+        if value.trim().is_empty() {
+          Err("host cannot be empty")
+        } else {
+          Ok(())
+        }
+      })
+      .interact_text()
+      .context("Failed to read remote host")?
+      .trim()
+      .to_string()
+  } else {
+    hosts[selection].clone()
+  };
+
+  Ok(host)
+}
+
+fn ssh_config_hosts() -> Vec<String> {
+  let Some(home) = std::env::var_os("HOME") else {
+    return vec![];
+  };
+  let config_path = PathBuf::from(home).join(".ssh/config");
+  fs::read_to_string(config_path).map(|contents| parse_ssh_config_hosts(&contents)).unwrap_or_default()
+}
+
+fn parse_ssh_config_hosts(config: &str) -> Vec<String> {
+  config
+    .lines()
+    .filter_map(|line| {
+      let line = line.split('#').next()?.trim();
+      let (keyword, value) = line.split_once(char::is_whitespace)?;
+      if !keyword.eq_ignore_ascii_case("host") {
+        return None;
+      }
+      Some(
+        value.split_whitespace().filter(|host| !host.contains(['*', '?', '!'])).map(str::to_string).collect::<Vec<_>>(),
+      )
+    })
+    .flatten()
+    .collect()
+}
+
+fn deduplicate(hosts: &mut Vec<String>) {
+  let mut seen = HashSet::new();
+  hosts.retain(|host| seen.insert(host.clone()));
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_literal_ssh_host_aliases() {
+    let config = r#"
+Host prod web
+  HostName prod.example.com
+
+host *.internal !bastion
+  User deploy
+
+HOST staging # a comment
+  HostName staging.example.com
+"#;
+
+    assert_eq!(parse_ssh_config_hosts(config), ["prod", "web", "staging"]);
+  }
+
+  #[test]
+  fn deduplicates_hosts_without_reordering_them() {
+    let mut hosts = vec!["recent".into(), "prod".into(), "recent".into(), "staging".into()];
+    deduplicate(&mut hosts);
+    assert_eq!(hosts, ["recent", "prod", "staging"]);
+  }
+}


### PR DESCRIPTION
Closes #102. `--host` is handy when I already know the destination, but it is a bit annoying when I just want to pick one of the aliases already in my SSH config.

This adds `-r` / `--remote`, which opens a small picker containing the literal `Host` aliases from `~/.ssh/config` plus an option to type a host manually. Wildcard entries are ignored because there is no concrete machine to select. Nothing is cached; OpenSSH remains responsible for resolving the selected alias and handling authentication.

`--host HOST` is unchanged for direct connections and scripts. Clap rejects using it together with `--remote`.

For example:

```text
Remote host:
> prod-web-1
  prod-web-2
  staging
  Enter a host manually…
```

## Testing

- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `tests/integration-test.py` (28 passed)
- checked `--help` and the `--remote` / `--host` conflict