### PR TITLE
Colorize log lines by journal priority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,6 +1961,7 @@ dependencies = [
  "log",
  "nix 0.31.2",
  "ratatui",
+ "serde_json",
  "signal-hook 0.4.3",
  "terminal-light",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ fuzzy-matcher = "0.3"
 itertools = "0.14.0"
 indexmap = "2.0.0"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
+serde_json = "1"
 lazy_static = "1.4.0"
 nix = { version = "0.31.0", features = ["user"] }
 is-wsl = "0.4.0"

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,5 +1,6 @@
 use crate::{
   components::home::Mode,
+  journal::LogEntry,
   systemd::{ServiceList, UnitFile, UnitId, UnitRuntimeInfo},
 };
 
@@ -25,8 +26,8 @@ pub enum Action {
   SetUnitFilePath { unit: UnitId, path: Result<String, String> },
   SetUnitRuntimeInfo { unit: UnitId, info: Box<UnitRuntimeInfo> },
   CopyUnitFilePath,
-  SetLogs { unit: UnitId, logs: Vec<String> },
-  AppendLogLine { unit: UnitId, line: String },
+  SetLogs { unit: UnitId, logs: Vec<LogEntry> },
+  AppendLogLines { unit: UnitId, lines: Vec<LogEntry> },
   StartService(UnitId),
   StopService(UnitId),
   RestartService(UnitId),

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -1,4 +1,3 @@
-use chrono::DateTime;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use futures::Future;
 use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
@@ -27,6 +26,7 @@ use std::{collections::HashSet, process::Stdio, time::Duration};
 use super::{logger::Logger, Component, Frame};
 use crate::{
   action::Action,
+  journal::{parse_json_log_line, LogEntry},
   systemd::{
     self, diagnose_missing_logs, parse_journalctl_error, Scope, UnitFile, UnitId, UnitRuntimeInfo, UnitScope,
     UnitWithStatus,
@@ -216,7 +216,7 @@ pub struct Home {
   pub show_logger: bool,
   pub all_units: IndexMap<UnitId, UnitWithStatus>,
   pub filtered_units: StatefulList<MatchedUnit>,
-  pub logs: Vec<String>,
+  pub logs: Vec<LogEntry>,
   pub logs_scroll_offset: u16,
   /// Maximum wrapped-line scroll offset calculated during the most recent render.
   pub logs_max_scroll_offset: u16,
@@ -385,8 +385,8 @@ impl Home {
 
   fn logs_for_pager(&self) -> Vec<String> {
     match self.log_order {
-      LogOrder::NewestFirst => self.logs.iter().rev().cloned().collect(),
-      LogOrder::OldestFirst => self.logs.clone(),
+      LogOrder::NewestFirst => self.logs.iter().rev().map(LogEntry::to_plain_string).collect(),
+      LogOrder::OldestFirst => self.logs.iter().map(LogEntry::to_plain_string).collect(),
     }
   }
 
@@ -812,7 +812,13 @@ impl Component for Home {
         info!("Getting logs for {}", unit.name);
         let start = std::time::Instant::now();
 
-        let mut args = vec!["--quiet", "--output=short-iso", "--lines=500", "-u"];
+        let mut args = vec![
+          "--quiet",
+          "--output=json",
+          "--output-fields=PRIORITY,MESSAGE,SYSLOG_IDENTIFIER,_COMM,_PID",
+          "--lines=500",
+          "-u",
+        ];
 
         args.push(&unit.name);
 
@@ -825,11 +831,12 @@ impl Component for Home {
             if output.status.success() {
               info!("Got logs for {} in {:?}", unit.name, start.elapsed());
               if let Ok(stdout) = std::str::from_utf8(&output.stdout) {
-                let mut logs = stdout.trim().split('\n').map(String::from).collect_vec();
+                let mut logs =
+                  stdout.trim().lines().filter(|l| !l.is_empty()).flat_map(parse_json_log_line).collect_vec();
 
-                if logs.is_empty() || logs[0].is_empty() {
+                if logs.is_empty() {
                   let diagnostic = diagnose_missing_logs(&unit);
-                  logs = vec![diagnostic.message()];
+                  logs = vec![LogEntry::plain(diagnostic.message())];
                 }
                 let _ = tx.send(Action::SetLogs { unit: unit.clone(), logs });
                 let _ = tx.send(Action::Render);
@@ -840,14 +847,17 @@ impl Component for Home {
               let stderr = String::from_utf8_lossy(&output.stderr);
               warn!("Error getting logs for {}: {}", unit.name, stderr);
               let diagnostic = parse_journalctl_error(&stderr);
-              let _ = tx.send(Action::SetLogs { unit: unit.clone(), logs: vec![diagnostic.message()] });
+              let _ =
+                tx.send(Action::SetLogs { unit: unit.clone(), logs: vec![LogEntry::plain(diagnostic.message())] });
               let _ = tx.send(Action::Render);
             }
           },
           Err(e) => {
             warn!("Error getting logs for {}: {}", unit.name, e);
-            let _ =
-              tx.send(Action::SetLogs { unit: unit.clone(), logs: vec![format!("Failed to run journalctl: {}", e)] });
+            let _ = tx.send(Action::SetLogs {
+              unit: unit.clone(),
+              logs: vec![LogEntry::plain(format!("Failed to run journalctl: {}", e))],
+            });
             let _ = tx.send(Action::Render);
           },
         }
@@ -857,7 +867,15 @@ impl Component for Home {
         // This does mean that we'll miss any logs that are written between the two commands, low enough risk for now
         let tx = tx.clone();
         last_follow_handle = Some(tokio::spawn(async move {
-          let mut args = vec!["-u", &unit.name, "--output=short-iso", "--follow", "--lines=0", "--quiet"];
+          let mut args = vec![
+            "-u",
+            &unit.name,
+            "--output=json",
+            "--output-fields=PRIORITY,MESSAGE,SYSLOG_IDENTIFIER,_COMM,_PID",
+            "--follow",
+            "--lines=0",
+            "--quiet",
+          ];
           if unit.scope == UnitScope::User {
             args.push("--user");
           }
@@ -873,7 +891,7 @@ impl Component for Home {
           let reader = tokio::io::BufReader::new(stdout);
           let mut lines = reader.lines();
           while let Some(line) = lines.next_line().await.unwrap() {
-            let _ = tx.send(Action::AppendLogLine { unit: unit.clone(), line });
+            let _ = tx.send(Action::AppendLogLines { unit: unit.clone(), lines: parse_json_log_line(&line) });
             let _ = tx.send(Action::Render);
           }
         }));
@@ -1421,10 +1439,10 @@ impl Component for Home {
           }
         }
       },
-      Action::AppendLogLine { unit, line } => {
+      Action::AppendLogLines { unit, lines } => {
         if let Some(selected) = self.filtered_units.selected() {
           if selected.unit.id() == unit {
-            self.logs.push(line);
+            self.logs.extend(lines);
             if self.log_order == LogOrder::OldestFirst && self.follow_logs {
               self.logs_scroll_offset = u16::MAX;
             }
@@ -1889,23 +1907,28 @@ impl Component for Home {
       f.render_widget(Paragraph::new(stat_values), panes[3]);
     }
 
-    let logs: Box<dyn Iterator<Item = &String>> = match self.log_order {
+    let logs: Box<dyn Iterator<Item = &LogEntry>> = match self.log_order {
       LogOrder::NewestFirst => Box::new(self.logs.iter().rev()),
       LogOrder::OldestFirst => Box::new(self.logs.iter()),
     };
     let log_lines = logs
-      .map(|l| {
-        if let Some((timestamp, rest)) = l.split_once(' ') {
-          if let Some(formatted_date) = parse_journalctl_timestamp(timestamp) {
-            return Line::from(vec![
-              Span::styled(formatted_date, Style::default().add_modifier(Modifier::DIM)),
-              Span::raw(" "),
-              Span::raw(rest),
-            ]);
-          }
+      .map(|entry| {
+        // Colorize by syslog priority, like journalctl does in a terminal:
+        // err and worse red, warnings yellow, debug dimmed.
+        let content_style = match entry.priority {
+          Some(p) if p <= 3 => Style::default().fg(Color::Red),
+          Some(4) => Style::default().fg(Color::Yellow),
+          Some(7) => Style::default().add_modifier(Modifier::DIM),
+          _ => Style::default(),
+        };
+        match &entry.timestamp {
+          Some(timestamp) => Line::from(vec![
+            Span::styled(timestamp.as_str(), Style::default().add_modifier(Modifier::DIM)),
+            Span::raw(" "),
+            Span::styled(entry.content.as_str(), content_style),
+          ]),
+          None => Line::from(Span::styled(entry.content.as_str(), content_style)),
         }
-
-        Line::from(l.as_str())
       })
       .collect_vec();
 
@@ -2386,11 +2409,6 @@ fn format_cpu_nsec(nsec: u64) -> String {
   }
 }
 
-fn parse_journalctl_timestamp(timestamp: &str) -> Option<String> {
-  // %z accepts both "-0700" (systemd <v255) and "-07:00" (systemd >=v255)
-  DateTime::parse_from_str(timestamp, "%Y-%m-%dT%H:%M:%S%z").ok().map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
-}
-
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -2444,26 +2462,45 @@ mod tests {
   }
 
   #[test]
-  fn test_parse_timestamp_systemd_v255_and_later() {
-    // systemd >=v255 uses RFC 3339 format with colon in timezone offset
-    // https://github.com/systemd/systemd/pull/29134
-    let timestamp = "2025-04-26T06:04:45-07:00";
-    let result = parse_journalctl_timestamp(timestamp);
-    assert_eq!(result, Some("2025-04-26 06:04".to_string()));
-  }
+  fn log_lines_are_colored_by_priority() {
+    use ratatui::{backend::TestBackend, Terminal};
 
-  #[test]
-  fn test_parse_timestamp_systemd_before_v255() {
-    // systemd <v255 uses ISO 8601 format without colon in timezone offset
-    let timestamp = "2025-10-06T11:07:44-0700";
-    let result = parse_journalctl_timestamp(timestamp);
-    assert_eq!(result, Some("2025-10-06 11:07".to_string()));
+    let mut home = Home::new(Scope::All, &[], LogOrder::NewestFirst);
+    let unit = test_unit("cron.service");
+    home.all_units.insert(unit.id(), unit.clone());
+    home.filtered_units.items = vec![MatchedUnit { unit, match_indices: vec![] }];
+    home.filtered_units.state.select(Some(0));
+    home.logs = vec![
+      LogEntry { timestamp: None, content: "an error".into(), priority: Some(3) },
+      LogEntry { timestamp: None, content: "a warning".into(), priority: Some(4) },
+      LogEntry { timestamp: None, content: "plain info".into(), priority: Some(6) },
+    ];
+
+    let backend = TestBackend::new(120, 40);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal.draw(|f| home.render(f, f.area())).unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let style_of = |needle: &str| {
+      let area = *buffer.area();
+      for y in 0..area.height {
+        let row: String = (0..area.width).map(|x| buffer[(x, y)].symbol()).collect();
+        if let Some(col) = row.find(needle) {
+          return buffer[(col as u16, y)].style();
+        }
+      }
+      panic!("{needle:?} not found in rendered buffer");
+    };
+
+    assert_eq!(style_of("an error").fg, Some(Color::Red));
+    assert_eq!(style_of("a warning").fg, Some(Color::Yellow));
+    assert_eq!(style_of("plain info").fg, Some(Color::Reset));
   }
 
   #[test]
   fn log_order_controls_pager_order() {
     let mut home = Home::new(Scope::All, &[], LogOrder::NewestFirst);
-    home.logs = vec!["oldest".into(), "newest".into()];
+    home.logs = vec![LogEntry::plain("oldest"), LogEntry::plain("newest")];
 
     assert_eq!(home.logs_for_pager(), ["newest", "oldest"]);
     home.dispatch(Action::ToggleLogOrder);

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,0 +1,134 @@
+//! Parsing of `journalctl --output=json` lines into structured log entries.
+//!
+//! We use JSON output (rather than `short-iso`) so we get the `PRIORITY` field, which
+//! lets us colorize errors/warnings the way `journalctl` does in a terminal.
+
+use chrono::{Local, TimeZone};
+use serde_json::Value;
+
+/// One displayable log line. Multi-line journal messages are split into multiple
+/// entries (continuation lines have no timestamp).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogEntry {
+  /// Local time, pre-formatted for display ("2026-07-15 10:04"). `None` for
+  /// continuation lines and non-journal messages (diagnostics, errors).
+  pub timestamp: Option<String>,
+  /// The rest of the line: "identifier[pid]: message" for journal entries.
+  pub content: String,
+  /// syslog priority 0-7 (0=emerg ... 7=debug), if the journal entry had one
+  pub priority: Option<u8>,
+}
+
+impl LogEntry {
+  /// A plain text line with no timestamp or priority (diagnostics, error messages).
+  pub fn plain(content: impl Into<String>) -> Self {
+    Self { timestamp: None, content: content.into(), priority: None }
+  }
+
+  /// Plain-text form, used when exporting logs to a pager.
+  pub fn to_plain_string(&self) -> String {
+    match &self.timestamp {
+      Some(ts) => format!("{} {}", ts, self.content),
+      None => self.content.clone(),
+    }
+  }
+}
+
+/// Parse one line of `journalctl --output=json` output. Returns one entry per line of
+/// the message (journal messages can be multi-line). Falls back to a plain entry with
+/// the raw line if it isn't valid JSON.
+pub fn parse_json_log_line(line: &str) -> Vec<LogEntry> {
+  let Ok(value) = serde_json::from_str::<Value>(line) else {
+    return vec![LogEntry::plain(line)];
+  };
+
+  let timestamp = value["__REALTIME_TIMESTAMP"]
+    .as_str()
+    .and_then(|us| us.parse::<i64>().ok())
+    .and_then(|us| Local.timestamp_micros(us).single())
+    .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string());
+
+  let priority = value["PRIORITY"].as_str().and_then(|p| p.parse::<u8>().ok());
+
+  let message = field_as_string(&value["MESSAGE"]).unwrap_or_default();
+
+  // "identifier[pid]: " prefix, like journalctl's short output
+  let identifier = value["SYSLOG_IDENTIFIER"].as_str().or_else(|| value["_COMM"].as_str());
+  let pid = value["_PID"].as_str();
+  let prefix = match (identifier, pid) {
+    (Some(id), Some(pid)) => format!("{id}[{pid}]: "),
+    (Some(id), None) => format!("{id}: "),
+    (None, _) => String::new(),
+  };
+
+  let mut lines = message.lines();
+  let first = lines.next().unwrap_or_default();
+  let mut entries = vec![LogEntry { timestamp, content: format!("{prefix}{first}"), priority }];
+  for continuation in lines {
+    entries.push(LogEntry { timestamp: None, content: format!("  {continuation}"), priority });
+  }
+  entries
+}
+
+/// Journal fields are usually JSON strings, but journalctl encodes non-UTF8 values as
+/// arrays of bytes. Handle both.
+fn field_as_string(value: &Value) -> Option<String> {
+  match value {
+    Value::String(s) => Some(s.clone()),
+    Value::Array(bytes) => {
+      let bytes: Vec<u8> = bytes.iter().filter_map(|b| b.as_u64().map(|b| b as u8)).collect();
+      Some(String::from_utf8_lossy(&bytes).into_owned())
+    },
+    _ => None,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_a_typical_entry() {
+    let line = r#"{"__REALTIME_TIMESTAMP":"1752598800000000","PRIORITY":"6","MESSAGE":"Started Docker.","SYSLOG_IDENTIFIER":"systemd","_PID":"1"}"#;
+    let entries = parse_json_log_line(line);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].priority, Some(6));
+    assert_eq!(entries[0].content, "systemd[1]: Started Docker.");
+    assert!(entries[0].timestamp.is_some());
+  }
+
+  #[test]
+  fn splits_multiline_messages() {
+    let line = r#"{"__REALTIME_TIMESTAMP":"1752598800000000","PRIORITY":"3","MESSAGE":"first\nsecond","SYSLOG_IDENTIFIER":"app"}"#;
+    let entries = parse_json_log_line(line);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].content, "app: first");
+    assert_eq!(entries[1].content, "  second");
+    assert_eq!(entries[1].timestamp, None);
+    assert_eq!(entries[1].priority, Some(3));
+  }
+
+  #[test]
+  fn handles_non_utf8_message_byte_arrays() {
+    let line = r#"{"MESSAGE":[104,105,255],"PRIORITY":"4"}"#;
+    let entries = parse_json_log_line(line);
+    assert_eq!(entries.len(), 1);
+    assert!(entries[0].content.starts_with("hi"));
+    assert_eq!(entries[0].priority, Some(4));
+  }
+
+  #[test]
+  fn falls_back_to_plain_on_invalid_json() {
+    let entries = parse_json_log_line("not json at all");
+    assert_eq!(entries, vec![LogEntry::plain("not json at all")]);
+  }
+
+  #[test]
+  fn missing_fields_are_tolerated() {
+    let entries = parse_json_log_line(r#"{"MESSAGE":"hello"}"#);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].content, "hello");
+    assert_eq!(entries[0].priority, None);
+    assert_eq!(entries[0].timestamp, None);
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ pub mod utils;
 
 pub mod systemd;
 
+pub mod journal;
+
 pub mod ssh;
 
 pub mod unit_descriptions;


### PR DESCRIPTION
Closes #100. Log lines are now colored by priority, the way `journalctl` colors them in a terminal: errors and worse are red, warnings are yellow, debug is dimmed.

<img width="2487" height="1436" alt="image" src="https://github.com/user-attachments/assets/a8281723-967c-4cf9-9bfa-00adb329dd37" />


## Deets

`journalctl`'s color decisions come from the journal's `PRIORITY` field (syslog levels 0-7), which our old `--output=short-iso` format did not include. Rather than forcing ANSI codes through with `SYSTEMD_COLORS=1` and parsing them back out, I switched both log paths (initial batch + `--follow` stream) to `--output=json` and we now apply our own styling:

1. New `src/journal.rs` parses JSON journal lines into a `LogEntry { timestamp, content, priority }` struct. It handles journalctl's quirks: non-UTF8 messages arrive as byte arrays, fields can be missing, and anything that is not valid JSON falls back to plain text.
2. `--output-fields=` limits the JSON to the fields we use, to keep remote mode from shipping every journal field over SSH. It needs systemd >= 236; the oldest host in our test matrix is 239.
3. Multi-line messages now render as indented continuation lines. The old code split raw output on newlines, so continuation lines showed up as garbage lines with no timestamp.

Some code got deleted along the way: timestamps now come from the raw `__REALTIME_TIMESTAMP` field, so the pre/post-v255 timestamp format parsing (`parse_journalctl_timestamp`) is gone.

One deliberate display change: log lines no longer show the hostname (`time proc[pid]: msg` instead of `time host proc[pid]: msg`). It was the same on every line and the message can use the space. Easy to re-add from `_HOSTNAME` if anyone misses it.

## Testing

- new unit tests for the JSON parsing and a render test asserting red/yellow at the buffer level
- drove the app in tmux against real journald units emitting every priority level, for both the initial batch and live-streamed lines
- `tests/remote-matrix.py` passes on all 8 hosts (Rocky 8 / systemd 239 through Fedora latest, plus the two hostile no-systemd hosts)
