### PR TITLE
Scroll logs two lines with page keys

### DIFF
--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -903,8 +903,8 @@ impl Component for Home {
     }
 
     match key.code {
-      KeyCode::PageDown => return vec![Action::ScrollDown(1), Action::Render],
-      KeyCode::PageUp => return vec![Action::ScrollUp(1), Action::Render],
+      KeyCode::PageDown => return vec![Action::ScrollDown(2), Action::Render],
+      KeyCode::PageUp => return vec![Action::ScrollUp(2), Action::Render],
       KeyCode::Home => return vec![Action::ScrollToTop, Action::Render],
       KeyCode::End => return vec![Action::ScrollToBottom, Action::Render],
       _ => (),


### PR DESCRIPTION
Related to #99. `PageUp` and `PageDown` only moved the logs by one line, which felt a bit sluggish.

This behavior was inspired by Lazygit which defaults to scrolling two lines at a time. Doing the same here feels better while preserving the existing small-increment behavior.

Will consider more improvements in this area (page at a time?), just wanted to get this small improvement in now.