### PR TITLE
Publish `.deb` packages as release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,3 +22,27 @@ jobs:
           target: ${{ matrix.target }}
           # (required) GitHub token for uploading assets to GitHub Releases.
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-debs:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-musl
+          - target: x86_64-unknown-linux-musl
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deb
+      - name: Build .deb
+        run: cargo deb --target ${{ matrix.target }} --output .
+      - name: Upload .deb to release
+        run: gh release upload "$GITHUB_REF_NAME" ./*.deb
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,17 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# Used by `cargo deb` to build Debian packages (see release.yml)
+[package.metadata.deb]
+section = "admin"
+priority = "optional"
+# Static musl binaries, so no runtime dependencies
+depends = ""
+extended-description = """\
+systemctl-tui is a fast, simple terminal user interface for interacting \
+with systemd services and their logs. It can quickly browse service status \
+and logs, and start/stop/restart/reload services."""
+
 [dependencies]
 ratatui = { version = "0.30.0", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.29.0", default-features = false, features = ["event-stream"] }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ curl https://raw.githubusercontent.com/rgwood/systemctl-tui/master/install.sh | 
 ```
 The script installs the downloaded binary to `$HOME/.local/bin` by default, but it can be changed by setting the `DIR` environment variable.
 
+### Debian/Ubuntu
+
+`.deb` packages (with no dependencies) are published in the [GitHub releases](https://github.com/rgwood/systemctl-tui/releases). Download the one for your architecture and install it with:
+
+```sh
+sudo apt install ./systemctl-tui_*.deb
+```
+
 ### Rust
 
 If you'd rather build from scratch you will need [Rust installed](https://rustup.rs/). Then either:


### PR DESCRIPTION
Related to #24.

Getting into apt proper means getting into Debian, which is a much bigger project. But since our release binaries are already static musl builds, packaging them as dependency-free `.deb`s is nearly free.

## Details

1. New `upload-debs` job in `release.yml` builds `.deb`s for x86_64 and aarch64 with [cargo-deb](https://github.com/kornelski/cargo-deb) and uploads them to the release.
2. New `[package.metadata.deb]` section in `Cargo.toml`: `admin` section, empty `Depends:` (the binaries are fully static), extended description.
3. Short Debian/Ubuntu install section in the README.

## Testing

Built `systemctl-tui_0.6.1-1_amd64.deb` locally, checked the control file with `dpkg-deb -I` (clean metadata, no dependencies), extracted it, and ran the binary — `--version` works and `file` confirms a static-pie executable. The workflow only runs on release creation, so the real end-to-end test is the next tagged release.