### PR TITLE
Handle remote disconnects gracefully instead of panicking

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -22,6 +22,7 @@ pub enum Action {
   SetUnitFiles(Vec<UnitFile>),
   EnterMode(Mode),
   EnterError(String),
+  ServicesRefreshFailed(String),
   CancelTask,
   ToggleHelp,
   SetUnitFilePath { unit: UnitId, path: Result<String, String> },

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -255,6 +255,7 @@ pub struct Home {
   pub cancel_token: Option<CancellationToken>,
   pub spinner_tick: u8,
   pub error_message: String,
+  pub refresh_error_shown: bool,
   pub action_tx: Option<mpsc::UnboundedSender<Action>>,
   pub journalctl_tx: Option<std::sync::mpsc::Sender<UnitId>>,
   pub fuzzy_matcher: SkimMatcherV2,
@@ -916,13 +917,20 @@ impl Component for Home {
           command.stderr(Stdio::piped());
           command.kill_on_drop(true);
 
-          let mut child = command.spawn().expect("failed to execute process");
+          let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(e) => {
+              error!("Failed to spawn journalctl: {:?}", e);
+              return;
+            },
+          };
 
-          let stdout = child.stdout.take().unwrap();
+          let Some(stdout) = child.stdout.take() else { return };
 
           let reader = tokio::io::BufReader::new(stdout);
           let mut lines = reader.lines();
-          while let Some(line) = lines.next_line().await.unwrap() {
+          // An Err on read (e.g. remote disconnect) just ends log following
+          while let Ok(Some(line)) = lines.next_line().await {
             let _ = tx.send(Action::AppendLogLines { unit: unit.clone(), lines: parse_json_log_line(&line) });
             let _ = tx.send(Action::Render);
           }
@@ -1493,6 +1501,14 @@ impl Component for Home {
         self.error_message = err;
         return Some(Action::EnterMode(Mode::Error));
       },
+      Action::ServicesRefreshFailed(err) => {
+        // The refresh tick retries continuously (e.g. after a remote disconnect); show the modal
+        // once rather than re-opening it every tick after the user dismisses it
+        if !self.refresh_error_shown {
+          self.refresh_error_shown = true;
+          return Some(Action::EnterError(err));
+        }
+      },
       Action::ToggleHelp => {
         if self.mode != Mode::Help {
           self.previous_mode = Some(self.mode);
@@ -1598,13 +1614,28 @@ impl Component for Home {
         let scope = self.scope;
         let limit_units = self.limit_units.to_vec();
         tokio::spawn(async move {
-          let units = systemd::get_all_services(scope, &limit_units)
-            .await
-            .expect("Failed to get services. Check that systemd is running and try running this tool with sudo.");
-          let _ = tx.send(Action::SetServices(units));
+          match systemd::get_all_services(scope, &limit_units).await {
+            Ok(units) => {
+              let _ = tx.send(Action::SetServices(units));
+            },
+            Err(e) => {
+              error!("Failed to get services: {:?}", e);
+              let error_string = match crate::ssh::remote_host() {
+                Some(ssh_host) => format!(
+                  "Lost connection to {} (or systemd stopped responding):\n{}\n\nRestart systemctl-tui to reconnect.",
+                  ssh_host.host, e
+                ),
+                None => {
+                  format!("Failed to get services:\n{e}\n\nCheck that systemd is running, or try running this tool with sudo.")
+                },
+              };
+              let _ = tx.send(Action::ServicesRefreshFailed(error_string));
+            },
+          }
         });
       },
       Action::SetServices(units) => {
+        self.refresh_error_shown = false;
         self.update_units(units);
         return Some(Action::Render);
       },

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -794,9 +794,9 @@ pub async fn get_active_state(connection: &Connection, full_service_name: &str) 
   let object_path = get_unit_path(full_service_name);
 
   match zvariant::ObjectPath::try_from(object_path) {
-    Ok(path) => {
-      let unit_proxy = UnitProxy::new(connection, path).await.unwrap();
-      unit_proxy.active_state().await.unwrap_or("invalid-unit-path".into())
+    Ok(path) => match UnitProxy::new(connection, path).await {
+      Ok(unit_proxy) => unit_proxy.active_state().await.unwrap_or("invalid-unit-path".into()),
+      Err(_) => "invalid-unit-path".to_string(),
     },
     Err(_) => "invalid-unit-path".to_string(),
   }
@@ -815,9 +815,9 @@ pub async fn get_unit_file_state(connection: &Connection, full_service_name: &st
   let object_path = get_unit_path(full_service_name);
 
   match zvariant::ObjectPath::try_from(object_path) {
-    Ok(path) => {
-      let unit_proxy = UnitProxy::new(connection, path).await.unwrap();
-      unit_proxy.unit_file_state().await.unwrap_or("invalid-unit-path".into())
+    Ok(path) => match UnitProxy::new(connection, path).await {
+      Ok(unit_proxy) => unit_proxy.unit_file_state().await.unwrap_or("invalid-unit-path".into()),
+      Err(_) => "invalid-unit-path".to_string(),
     },
     Err(_) => "invalid-unit-path".to_string(),
   }
@@ -833,9 +833,9 @@ pub async fn get_unit_file_state(connection: &Connection, full_service_name: &st
 pub async fn get_main_pid(connection: &Connection, full_service_name: &str) -> Result<u32, zbus::Error> {
   let object_path = get_unit_path(full_service_name);
 
-  let validated_object_path = zvariant::ObjectPath::try_from(object_path).unwrap();
+  let validated_object_path = zvariant::ObjectPath::try_from(object_path)?;
 
-  let service_proxy = ServiceProxy::new(connection, validated_object_path).await.unwrap();
+  let service_proxy = ServiceProxy::new(connection, validated_object_path).await?;
   service_proxy.main_pid().await
 }
 

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -18,10 +18,12 @@ passwordless ssh to the target.
 """
 
 import argparse
+import glob
 import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 
 # unique per run so concurrent invocations (e.g. remote-matrix.py against several
@@ -553,6 +555,41 @@ def test_journal_access_diagnostic(binary: str, nojournal_host: str) -> None:
     )
 
 
+def test_disconnect_recovery(binary: str, host: str) -> None:
+    """The app must survive losing the SSH connection mid-session (issue #111):
+    one error modal, no panic, no modal re-spam after dismissal, clean exit."""
+    print("disconnect recovery:")
+    start_app(binary, host)
+    if not wait_for(lambda: "Description:" in capture()):
+        check("app launches and renders", False, capture())
+        return
+
+    # Killing the mux master makes every subsequent SSH call fail with a broken
+    # pipe - same symptom as a remote reboot, without needing to reboot anything.
+    # The control path format matches ssh::init (systemctl-tui-ssh-<pid>-<hash>);
+    # match on our app's PID so concurrent instances (remote-matrix.py) don't
+    # kill each other's masters.
+    app_pid = tmux("list-panes", "-t", SESSION, "-F", "#{pane_pid}").stdout.strip()
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR", tempfile.gettempdir())
+    socks = glob.glob(os.path.join(runtime_dir, f"systemctl-tui-ssh-{app_pid}-*"))
+    if not socks:
+        check("found SSH control socket", False, f"no systemctl-tui-ssh-{app_pid}-* in {runtime_dir}")
+        return
+    run(["ssh", "-o", f"ControlPath={socks[0]}", "-O", "exit", "--", host])
+
+    # the 5s refresh tick notices the dead connection
+    check("connection-lost modal appears", wait_for(lambda: "Lost connection" in capture(), timeout=30), capture())
+    check("app still alive (no panic)", app_alive(), capture())
+
+    send_keys("Escape")
+    time.sleep(12)  # at least two refresh ticks
+    check("modal stays dismissed across refresh ticks", "Lost connection" not in capture(), capture())
+    check("app still alive after dismissal", app_alive())
+
+    send_keys("q")
+    check("q exits cleanly after disconnect", wait_for(lambda: not app_alive(), timeout=10))
+
+
 def test_missing_bridge_error_path(binary: str, root_host: str) -> None:
     """Must run last: it temporarily breaks systemd-stdio-bridge on the remote host."""
     print("missing-bridge error path:")
@@ -639,6 +676,7 @@ def main() -> int:
             test_log_rendering(args.binary, args.host)
             test_follow_mode_streams(args.binary, root_host)
             test_journal_access_diagnostic(args.binary, nojournal_host)
+            test_disconnect_recovery(args.binary, args.host)
             # last: this one breaks systemd-stdio-bridge on the remote host
             test_missing_bridge_error_path(args.binary, root_host)
     finally:

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -296,7 +296,10 @@ def test_mouse(binary: str, host: str | None) -> None:
         time.sleep(0.3)
 
     # 4. drag-selecting log text copies it and shows a toast
-    logs_title_row = next(i for i, line in enumerate(capture().splitlines()) if "Logs —" in line)
+    logs_title_row = next((i for i, line in enumerate(capture().splitlines()) if "Logs —" in line), None)
+    if logs_title_row is None:
+        check("logs pane present for drag test", False, capture())
+        return
     drag_row = logs_title_row + 2  # tmux mouse coordinates are 1-based; use the first log-content row
     send_mouse("press", 40, drag_row)
     time.sleep(0.1)


### PR DESCRIPTION
Closes #111. If a remote host rebooted while you were connected with `--host`, the app died with a full backtrace. The services list refreshes every 5 seconds on a background task, and that task called `.expect()` on the result — so a dead SSH connection reliably panicked.

Now the app stays alive and shows one dismissable error modal:

```
Lost connection to potato-pi (or systemd stopped responding):
I/O error: Broken pipe (os error 32)

Restart systemctl-tui to reconnect.
```

## Details

1. The `RefreshServices` task now matches on the result like its sibling handlers, and sends a new `ServicesRefreshFailed` action on error.
2. Since the refresh tick retries forever, a naive fix re-opens the modal every 5 seconds after you dismiss it (my first attempt did exactly this, oops). A `refresh_error_shown` flag shows the modal once, and resets when a refresh succeeds — so a recovered connection can surface a new error later.
3. While I was in the area I fixed the other panics the same disconnect triggers: the journalctl `--follow` task's unwraps (a read error now just ends log following quietly) and the `UnitProxy`/`ServiceProxy` unwraps in the unit-info path.

I kept this deliberately minimal — no reconnect logic. Restarting the app reconnects, and IMO that's fine for how often this happens.

## Testing

Added a `disconnect recovery` test to the remote suite. It kills the SSH mux master with `ssh -O exit`, which makes every later call fail with the same broken pipe as a real reboot — no actual reboot needed. It asserts: modal appears, no panic, modal stays dismissed across refresh ticks, `q` still exits cleanly. It matches the control socket by the app's PID so concurrent matrix runs don't kill each other's connections.

Also verified by hand against a real host (killed the master mid-session, watched the modal appear once and stay dismissed). `tests/remote-matrix.py --distro ubuntu-24.04` passes 69/69, local suite passes 32/32, fmt and clippy are clean.