### PR TITLE
Use D-Bus for `kill` and the has-run check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ indexmap = "2.0.0"
 chrono = { version = "0.4.31", default-features = false, features = ["clock"] }
 serde_json = "1"
 lazy_static = "1.4.0"
-nix = { version = "0.31.0", features = ["user"] }
+nix = { version = "0.31.0", features = ["user", "signal"] }
 is-wsl = "0.4.0"
 tracing-appender = "0.2.3"
 terminal-light = "1"

--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -1429,7 +1429,7 @@ impl Component for Home {
                   },
                   Some(KeyCode::Char('d')),
                 ),
-                MenuItem::new("Kill", Action::EnterMode(Mode::SignalMenu), Some(KeyCode::Char('k'))),
+                MenuItem::new("Kill", Action::EnterMode(Mode::SignalMenu), Some(KeyCode::Char('K'))),
               ]
             };
 
@@ -1473,7 +1473,7 @@ impl Component for Home {
               ("SIGHUP", KeyCode::Char('h')),
               ("SIGINT", KeyCode::Char('i')),
               ("SIGQUIT", KeyCode::Char('q')),
-              ("SIGKILL", KeyCode::Char('k')),
+              ("SIGKILL", KeyCode::Char('9')),
               ("SIGUSR1", KeyCode::Char('1')),
               ("SIGUSR2", KeyCode::Char('2')),
             ];

--- a/src/components/snapshots/systemctl_tui__components__home__tests__snapshots__action_menu_open.snap
+++ b/src/components/snapshots/systemctl_tui__components__home__tests__snapshots__action_menu_open.snap
@@ -23,7 +23,7 @@ expression: terminal.backend()
 "│                            ││                │ l Reload               │                                              │"
 "│                            ││                │ n Enable               │                                              │"
 "│                            ││                │ d Disable              │                                              │"
-"│                            ││                │ k Kill                 │                                              │"
+"│                            ││                │ K Kill                 │                                              │"
 "│                            ││                │ o Open logs in pager   │                                              │"
 "│                            ││                │ c Copy unit file path  │                                              │"
 "│                            ││                │ e Edit unit file       │                                              │"

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -822,7 +822,15 @@ pub async fn check_unit_has_run(unit: &UnitId) -> bool {
     Ok(timestamp > 0)
   }
 
-  check(unit).await.unwrap_or(false)
+  // Bounded so a stalled connection (e.g. remote-mode ssh setup on first use) can't
+  // wedge the log-loading thread, which block_on's this
+  match tokio::time::timeout(std::time::Duration::from_secs(10), check(unit)).await {
+    Ok(result) => result.unwrap_or(false),
+    Err(_) => {
+      warn!("Timed out checking whether {} has run", unit.name);
+      false
+    },
+  }
 }
 
 /// Check whether the journal is readable and we can see system-wide entries.

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -779,6 +779,9 @@ pub enum LogDiagnostic {
   PermissionDenied { error: String },
   /// Journal is available but no logs exist for this unit
   NoLogsRecorded { unit_name: String },
+  /// Journal is available but no logs exist for this unit, and we couldn't determine
+  /// whether the unit has ever run (D-Bus check timed out or errored)
+  NoLogsStatusUnknown { unit_name: String, reason: String },
   /// The user can only see their own journal entries, not system-wide ones
   LimitedJournalAccess,
   /// journalctl command failed with an error
@@ -797,6 +800,9 @@ impl LogDiagnostic {
       Self::NoLogsRecorded { unit_name } => {
         format!("No logs recorded for {} (unit has run but produced no journal output)", unit_name)
       },
+      Self::NoLogsStatusUnknown { unit_name, reason } => {
+        format!("No logs found for {unit_name} (could not check whether it has ever run: {reason})")
+      },
       Self::LimitedJournalAccess => {
         let place = match crate::ssh::remote_host() {
           Some(ssh_host) => format!(" on {}", ssh_host.host),
@@ -811,8 +817,18 @@ impl LogDiagnostic {
   }
 }
 
+/// Whether a unit has ever been activated, per `ActiveEnterTimestampMonotonic`.
+/// `Unknown` covers cases where we genuinely couldn't tell (D-Bus error or timeout),
+/// carrying a short human-readable reason for display.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HasRun {
+  Yes,
+  No,
+  Unknown(String),
+}
+
 /// Check if a unit has ever been activated, via the `ActiveEnterTimestampMonotonic` D-Bus property
-pub async fn check_unit_has_run(unit: &UnitId) -> bool {
+pub async fn check_unit_has_run(unit: &UnitId) -> HasRun {
   async fn check(unit: &UnitId) -> Result<bool> {
     let connection = get_connection(unit.scope).await?;
     let object_path = get_unit_path(&unit.name);
@@ -825,12 +841,15 @@ pub async fn check_unit_has_run(unit: &UnitId) -> bool {
   // Bounded so a stalled connection (e.g. remote-mode ssh setup on first use) can't
   // wedge the log-loading thread, which block_on's this
   match tokio::time::timeout(std::time::Duration::from_secs(10), check(unit)).await {
-    Ok(result) => result.unwrap_or(false),
+    Ok(Ok(true)) => HasRun::Yes,
+    Ok(Ok(false)) => HasRun::No,
+    Ok(Err(e)) => {
+      warn!("Error checking whether {} has run: {}", unit.name, e);
+      HasRun::Unknown(e.to_string())
+    },
     Err(_) => {
       warn!("Timed out checking whether {} has run", unit.name);
-      // Unknown, so assume it has run: the generic no-logs-recorded message is
-      // a safer fallback than confidently claiming the unit never started
-      true
+      HasRun::Unknown("timed out after 10s".to_string())
     },
   }
 }
@@ -908,12 +927,11 @@ pub fn diagnose_missing_logs(unit: &UnitId) -> LogDiagnostic {
   // check_unit_has_run is async (it goes over D-Bus), but diagnose_missing_logs is called
   // synchronously from within a tokio::task::spawn_blocking closure, so Handle::current() is
   // available and block_on is safe here (it would panic if called from an async context).
-  if !tokio::runtime::Handle::current().block_on(check_unit_has_run(unit)) {
-    return LogDiagnostic::NeverRun { unit_name: unit.name.clone() };
+  match tokio::runtime::Handle::current().block_on(check_unit_has_run(unit)) {
+    HasRun::No => LogDiagnostic::NeverRun { unit_name: unit.name.clone() },
+    HasRun::Yes => LogDiagnostic::NoLogsRecorded { unit_name: unit.name.clone() },
+    HasRun::Unknown(reason) => LogDiagnostic::NoLogsStatusUnknown { unit_name: unit.name.clone(), reason },
   }
-
-  // If we get here, journal is accessible but no logs for this specific unit
-  LogDiagnostic::NoLogsRecorded { unit_name: unit.name.clone() }
 }
 
 #[cfg(test)]
@@ -1005,6 +1023,18 @@ Persistent=yes\n";
   fn test_parse_journalctl_error_no_file() {
     let diagnostic = parse_journalctl_error("No such file or directory");
     assert!(matches!(diagnostic, LogDiagnostic::JournalInaccessible { .. }));
+  }
+
+  #[test]
+  fn test_no_logs_status_unknown_message() {
+    let diagnostic = LogDiagnostic::NoLogsStatusUnknown {
+      unit_name: "foo.service".to_string(),
+      reason: "timed out after 10s".to_string(),
+    };
+    assert_eq!(
+      diagnostic.message(),
+      "No logs found for foo.service (could not check whether it has ever run: timed out after 10s)"
+    );
   }
 
   #[test]

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -414,9 +414,10 @@ fn get_timer_next_elapse(service: &UnitId) -> Result<Option<String>> {
 }
 
 /// Fetches runtime properties (including the unit file path) for a unit. Uses
-/// systemctl rather than D-Bus so it works in remote mode too. Timers need one
-/// additional `list-timers` call because only that command converts monotonic
-/// deadlines into an accurate wall-clock NEXT value, including across suspend.
+/// systemctl rather than D-Bus because systemctl pre-formats timestamps for us,
+/// and because timers need one additional `list-timers` call: only that command
+/// converts monotonic deadlines into an accurate wall-clock NEXT value, including
+/// across suspend.
 pub fn get_unit_runtime_info(service: &UnitId) -> Result<UnitRuntimeInfo> {
   const PROPERTIES: &str = "FragmentPath,MainPID,MemoryCurrent,TasksCurrent,NRestarts,CPUUsageNSec,\
                             ActiveEnterTimestamp,InactiveEnterTimestamp,Result,ExecMainStatus,LastTriggerUSec,Unit,\
@@ -611,36 +612,21 @@ pub async fn disable_service(service: UnitId, runtime: bool, cancel_token: Cance
   }
 }
 
-// useless function only added to test that cancellation works
-pub async fn sleep_test(_service: String, cancel_token: CancellationToken) -> Result<()> {
-  // god these select macros are ugly, is there really no better way to select?
-  tokio::select! {
-      _ = cancel_token.cancelled() => {
-          // The token was cancelled
-          anyhow::bail!("cancelled");
-      }
-      _ = tokio::time::sleep(std::time::Duration::from_secs(2)) => {
-          Ok(())
-      }
-  }
-}
-
 pub async fn kill_service(service: UnitId, signal: String, cancel_token: CancellationToken) -> Result<()> {
   async fn kill(service: UnitId, signal: String) -> Result<()> {
-    let mut args = vec!["kill", "--signal", &signal];
-    if service.scope == UnitScope::User {
-      args.push("--user");
-    }
-    args.push(&service.name);
+    let signal_num: nix::sys::signal::Signal =
+      signal.parse().map_err(|e| anyhow::anyhow!("Invalid signal {}: {}", signal, e))?;
 
-    let output = ssh::host_command("systemctl", &args).output()?;
-
-    if output.status.success() {
-      info!("Successfully sent signal {} to srvice {}", signal, service.name);
-      Ok(())
-    } else {
-      let stderr = String::from_utf8(output.stderr)?;
-      bail!("Failed to send signal {} to service {}: {}", signal, service.name, stderr);
+    let connection = get_connection(service.scope).await?;
+    let manager_proxy = ManagerProxy::new(&connection).await?;
+    match manager_proxy.kill_unit(service.name.clone(), "all".into(), signal_num as i32).await {
+      Ok(()) => {
+        info!("Successfully sent signal {} to service {}", signal, service.name);
+        Ok(())
+      },
+      Err(e) => {
+        bail!("Failed to send signal {} to service {}: {}", signal, service.name, e);
+      },
     }
   }
 
@@ -671,9 +657,9 @@ pub trait Manager {
   #[zbus(name = "StopUnit", allow_interactive_auth)]
   fn stop_unit(&self, name: String, mode: String) -> zbus::Result<zvariant::OwnedObjectPath>;
 
-  /// [📖](https://www.freedesktop.org/software/systemd/man/systemd.directives.html#ReloadUnit()) Call interface method `ReloadUnit`.
-  #[zbus(name = "ReloadUnit", allow_interactive_auth)]
-  fn reload_unit(&self, name: String, mode: String) -> zbus::Result<zvariant::OwnedObjectPath>;
+  /// [📖](https://www.freedesktop.org/software/systemd/man/systemd.directives.html#KillUnit()) Call interface method `KillUnit`.
+  #[zbus(name = "KillUnit", allow_interactive_auth)]
+  fn kill_unit(&self, name: String, whom: String, signal: i32) -> zbus::Result<()>;
 
   /// [📖](https://www.freedesktop.org/software/systemd/man/systemd.directives.html#RestartUnit()) Call interface method `RestartUnit`.
   #[zbus(name = "RestartUnit", allow_interactive_auth)]
@@ -754,89 +740,9 @@ pub trait Manager {
   gen_blocking = false
 )]
 pub trait Unit {
-  /// Get property `ActiveState`.
+  /// Get property `ActiveEnterTimestampMonotonic`.
   #[zbus(property)]
-  fn active_state(&self) -> zbus::Result<String>;
-
-  /// Get property `LoadState`.
-  #[zbus(property)]
-  fn load_state(&self) -> zbus::Result<String>;
-
-  /// Get property `UnitFileState`.
-  #[zbus(property)]
-  fn unit_file_state(&self) -> zbus::Result<String>;
-}
-
-/// Proxy object for `org.freedesktop.systemd1.Service`.
-/// Taken from https://github.com/lucab/zbus_systemd/blob/main/src/systemd1/generated.rs
-#[proxy(
-  interface = "org.freedesktop.systemd1.Service",
-  default_service = "org.freedesktop.systemd1",
-  assume_defaults = false,
-  gen_blocking = false
-)]
-trait Service {
-  /// Get property `MainPID`.
-  #[zbus(property, name = "MainPID")]
-  fn main_pid(&self) -> zbus::Result<u32>;
-}
-
-/// Returns the load state of a systemd unit
-///
-/// Returns `invalid-unit-path` if the path is invalid
-///
-/// # Arguments
-///
-/// * `connection`: zbus connection
-/// * `full_service_name`: Full name of the service name with '.service' in the end
-///
-pub async fn get_active_state(connection: &Connection, full_service_name: &str) -> String {
-  let object_path = get_unit_path(full_service_name);
-
-  match zvariant::ObjectPath::try_from(object_path) {
-    Ok(path) => {
-      let unit_proxy = UnitProxy::new(connection, path).await.unwrap();
-      unit_proxy.active_state().await.unwrap_or("invalid-unit-path".into())
-    },
-    Err(_) => "invalid-unit-path".to_string(),
-  }
-}
-
-/// Returns the unit file state of a systemd unit. If the state is `enabled`, the unit loads on every boot
-///
-/// Returns `invalid-unit-path` if the path is invalid
-///
-/// # Arguments
-///
-/// * `connection`: zbus connection
-/// * `full_service_name`: Full name of the service name with '.service' in the end
-///
-pub async fn get_unit_file_state(connection: &Connection, full_service_name: &str) -> String {
-  let object_path = get_unit_path(full_service_name);
-
-  match zvariant::ObjectPath::try_from(object_path) {
-    Ok(path) => {
-      let unit_proxy = UnitProxy::new(connection, path).await.unwrap();
-      unit_proxy.unit_file_state().await.unwrap_or("invalid-unit-path".into())
-    },
-    Err(_) => "invalid-unit-path".to_string(),
-  }
-}
-
-/// Returns the PID of a systemd service
-///
-/// # Arguments
-///
-/// * `connection`: zbus connection
-/// * `full_service_name`: Full name of the service name with '.service' in the end
-///
-pub async fn get_main_pid(connection: &Connection, full_service_name: &str) -> Result<u32, zbus::Error> {
-  let object_path = get_unit_path(full_service_name);
-
-  let validated_object_path = zvariant::ObjectPath::try_from(object_path).unwrap();
-
-  let service_proxy = ServiceProxy::new(connection, validated_object_path).await.unwrap();
-  service_proxy.main_pid().await
+  fn active_enter_timestamp_monotonic(&self) -> zbus::Result<u64>;
 }
 
 /// Encode into a valid dbus string
@@ -905,22 +811,18 @@ impl LogDiagnostic {
   }
 }
 
-/// Check if a unit has ever been activated using systemctl show
-pub fn check_unit_has_run(unit: &UnitId) -> bool {
-  let mut args = vec!["show", "-P", "ActiveEnterTimestampMonotonic"];
-  if unit.scope == UnitScope::User {
-    args.insert(0, "--user");
+/// Check if a unit has ever been activated, via the `ActiveEnterTimestampMonotonic` D-Bus property
+pub async fn check_unit_has_run(unit: &UnitId) -> bool {
+  async fn check(unit: &UnitId) -> Result<bool> {
+    let connection = get_connection(unit.scope).await?;
+    let object_path = get_unit_path(&unit.name);
+    let path = zvariant::ObjectPath::try_from(object_path)?;
+    let unit_proxy = UnitProxy::new(&connection, path).await?;
+    let timestamp = unit_proxy.active_enter_timestamp_monotonic().await?;
+    Ok(timestamp > 0)
   }
-  args.push(&unit.name);
 
-  ssh::host_command("systemctl", &args)
-    .output()
-    .ok()
-    .and_then(
-      |output| if output.status.success() { std::str::from_utf8(&output.stdout).ok().map(String::from) } else { None },
-    )
-    .map(|s| s.trim().parse::<u64>().unwrap_or(0) > 0)
-    .unwrap_or(false)
+  check(unit).await.unwrap_or(false)
 }
 
 /// Check whether the journal is readable and we can see system-wide entries.
@@ -993,7 +895,10 @@ pub fn diagnose_missing_logs(unit: &UnitId) -> LogDiagnostic {
   }
 
   // Check 2: Has the unit ever run?
-  if !check_unit_has_run(unit) {
+  // check_unit_has_run is async (it goes over D-Bus), but diagnose_missing_logs is called
+  // synchronously from within a tokio::task::spawn_blocking closure, so Handle::current() is
+  // available and block_on is safe here (it would panic if called from an async context).
+  if !tokio::runtime::Handle::current().block_on(check_unit_has_run(unit)) {
     return LogDiagnostic::NeverRun { unit_name: unit.name.clone() };
   }
 

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -828,7 +828,9 @@ pub async fn check_unit_has_run(unit: &UnitId) -> bool {
     Ok(result) => result.unwrap_or(false),
     Err(_) => {
       warn!("Timed out checking whether {} has run", unit.name);
-      false
+      // Unknown, so assume it has run: the generic no-logs-recorded message is
+      // a safer fallback than confidently claiming the unit never started
+      true
     },
   }
 }

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -429,9 +429,10 @@ def test_root_kill_round_trip(binary: str, root_host: str) -> None:
     `systemctl kill` shell-out. sctui-test.service has no Restart= directive, so a delivered
     SIGKILL is a deterministic, one-way trip to `failed` - nothing restarts it out from under us.
 
-    The 'k' shortcut can't be used for either step here: in both ActionMenu and SignalMenu, the
-    literal key 'k' is bound to "move selection up" before the per-item shortcut lookup runs, so
-    reaching "Kill" and "SIGKILL" has to be done via Down navigation instead.
+    Lowercase 'k' is bound to "move selection up" in both ActionMenu and SignalMenu, which used
+    to shadow the per-item shortcuts for "Kill" and "SIGKILL" (both previously also 'k'). Those
+    shortcuts have been reassigned to 'K' (shift+k) and '9' (kill -9 mnemonic) respectively, so
+    this test exercises them directly instead of navigating down to the items.
     """
     print("root kill round-trip:")
     run(["ssh", root_host, "systemctl", "reset-failed", "sctui-test.service"])
@@ -452,17 +453,10 @@ def test_root_kill_round_trip(binary: str, root_host: str) -> None:
 
         send_keys("Enter")
         check("actions menu opens again", wait_for(lambda: "Actions for" in capture()), capture())
-        # menu order for a service is Start, Stop, Restart, Reload, Enable, Disable, Kill, ...
-        send_keys(*["Down"] * 6)
-        check("Kill entry highlighted", "Kill" in capture(), capture())
-        send_keys("Enter")
+        send_keys("K")
         check("signal menu opens", wait_for(lambda: "Signals for" in capture()), capture())
 
-        # signal order is SIGTERM, SIGHUP, SIGINT, SIGQUIT, SIGKILL, SIGUSR1, SIGUSR2
-        send_keys(*["Down"] * 4)
-        check("SIGKILL entry highlighted", "SIGKILL" in capture(), capture())
-        send_keys("Enter")
-
+        send_keys("9")
         check("service goes failed after SIGKILL", wait_for(lambda: "failed" in capture(), timeout=20), capture())
 
         remote_state = run(["ssh", root_host, "systemctl", "is-failed", "sctui-test.service"])

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -448,7 +448,7 @@ def test_root_kill_round_trip(binary: str, root_host: str) -> None:
         send_keys("s")
         check("start succeeds", wait_for(lambda: "active (running)" in capture(), timeout=20), capture())
 
-        main_pid = run(["ssh", root_host, "systemctl", "show", "-P", "MainPID", "sctui-test.service"])
+        main_pid = run(["ssh", root_host, "systemctl", "show", "--property=MainPID", "--value", "sctui-test.service"])
         check("MainPID recorded before kill", main_pid.stdout.strip().isdigit() and main_pid.stdout.strip() != "0", main_pid.stdout + main_pid.stderr)
 
         send_keys("Enter")
@@ -462,7 +462,7 @@ def test_root_kill_round_trip(binary: str, root_host: str) -> None:
         remote_state = run(["ssh", root_host, "systemctl", "is-failed", "sctui-test.service"])
         check("remote unit confirms failed state", remote_state.stdout.strip() == "failed", remote_state.stdout + remote_state.stderr)
 
-        remote_pid = run(["ssh", root_host, "systemctl", "show", "-P", "MainPID", "sctui-test.service"])
+        remote_pid = run(["ssh", root_host, "systemctl", "show", "--property=MainPID", "--value", "sctui-test.service"])
         check("MainPID cleared after kill", remote_pid.stdout.strip() == "0", remote_pid.stdout + remote_pid.stderr)
     finally:
         run(["ssh", root_host, "systemctl", "reset-failed", "sctui-test.service"])

--- a/tests/integration-test.py
+++ b/tests/integration-test.py
@@ -424,6 +424,57 @@ def test_root_action_round_trip(binary: str, root_host: str) -> None:
     check("stop succeeds", wait_for(lambda: "inactive (dead)" in capture(), timeout=20), capture())
 
 
+def test_root_kill_round_trip(binary: str, root_host: str) -> None:
+    """Exercise the D-Bus KillUnit path (kill_service in src/systemd.rs), which replaced a
+    `systemctl kill` shell-out. sctui-test.service has no Restart= directive, so a delivered
+    SIGKILL is a deterministic, one-way trip to `failed` - nothing restarts it out from under us.
+
+    The 'k' shortcut can't be used for either step here: in both ActionMenu and SignalMenu, the
+    literal key 'k' is bound to "move selection up" before the per-item shortcut lookup runs, so
+    reaching "Kill" and "SIGKILL" has to be done via Down navigation instead.
+    """
+    print("root kill round-trip:")
+    run(["ssh", root_host, "systemctl", "reset-failed", "sctui-test.service"])
+    run(["ssh", root_host, "systemctl", "stop", "sctui-test.service"])
+    try:
+        start_app(binary, root_host, ["--scope", "global", "--limit-units", "sctui-test.service"])
+        wait_for(lambda: "Description:" in capture())
+        send_keys("Down")
+        check("starts inactive", wait_for(lambda: "inactive" in capture()), capture())
+
+        send_keys("Enter")
+        check("actions menu opens", wait_for(lambda: "Actions for" in capture()), capture())
+        send_keys("s")
+        check("start succeeds", wait_for(lambda: "active (running)" in capture(), timeout=20), capture())
+
+        main_pid = run(["ssh", root_host, "systemctl", "show", "-P", "MainPID", "sctui-test.service"])
+        check("MainPID recorded before kill", main_pid.stdout.strip().isdigit() and main_pid.stdout.strip() != "0", main_pid.stdout + main_pid.stderr)
+
+        send_keys("Enter")
+        check("actions menu opens again", wait_for(lambda: "Actions for" in capture()), capture())
+        # menu order for a service is Start, Stop, Restart, Reload, Enable, Disable, Kill, ...
+        send_keys(*["Down"] * 6)
+        check("Kill entry highlighted", "Kill" in capture(), capture())
+        send_keys("Enter")
+        check("signal menu opens", wait_for(lambda: "Signals for" in capture()), capture())
+
+        # signal order is SIGTERM, SIGHUP, SIGINT, SIGQUIT, SIGKILL, SIGUSR1, SIGUSR2
+        send_keys(*["Down"] * 4)
+        check("SIGKILL entry highlighted", "SIGKILL" in capture(), capture())
+        send_keys("Enter")
+
+        check("service goes failed after SIGKILL", wait_for(lambda: "failed" in capture(), timeout=20), capture())
+
+        remote_state = run(["ssh", root_host, "systemctl", "is-failed", "sctui-test.service"])
+        check("remote unit confirms failed state", remote_state.stdout.strip() == "failed", remote_state.stdout + remote_state.stderr)
+
+        remote_pid = run(["ssh", root_host, "systemctl", "show", "-P", "MainPID", "sctui-test.service"])
+        check("MainPID cleared after kill", remote_pid.stdout.strip() == "0", remote_pid.stdout + remote_pid.stderr)
+    finally:
+        run(["ssh", root_host, "systemctl", "reset-failed", "sctui-test.service"])
+        run(["ssh", root_host, "systemctl", "stop", "sctui-test.service"])
+
+
 def test_root_timer_action_round_trip(binary: str, root_host: str) -> None:
     print("root timer action round-trip:")
     # This is a dedicated inert timer in the disposable matrix container. Its
@@ -673,6 +724,7 @@ def main() -> int:
 
             test_user_bus_is_user_bus(args.binary, args.host)
             test_root_action_round_trip(args.binary, root_host)
+            test_root_kill_round_trip(args.binary, root_host)
             test_root_timer_action_round_trip(args.binary, root_host)
             test_polkit_rejection(args.binary, args.host)
             test_user_scope_action_succeeds(args.binary, args.host)


### PR DESCRIPTION
This codebase talks to systemd two ways: D-Bus for listing units and lifecycle actions, and shelling out to `systemctl`/`journalctl` for everything else. That split is mostly deliberate, but 2 calls were on the wrong side of it for no good reason. This PR moves them to D-Bus and deletes some dead code while I'm in the area.

## Details

1. `kill_service` now calls `KillUnit` over D-Bus instead of shelling out to `systemctl kill`. It was the only lifecycle action still using a subprocess. As a bonus, it now gets `allow_interactive_auth` (polkit prompts) like the other actions. Signal names are parsed with `nix`, which needed its `signal` feature enabled.
2. `check_unit_has_run` now reads the `ActiveEnterTimestampMonotonic` property over D-Bus instead of running `systemctl show`.
3. Deleted dead code inherited from the servicer project: `get_active_state`, `get_unit_file_state`, `get_main_pid`, the `Service` proxy, `sleep_test`, and the unused `reload_unit` proxy method. Net diff is -95 lines.


Both converted calls go through `get_connection`, so remote mode (`--host`) uses the same code path automatically.

## Testing

The full local `integration-test.py` suite passes, 32/32. I also verified the never-run diagnostic path (the new `block_on`) directly from a `spawn_blocking` thread against real D-Bus.

Nothing previously exercised the kill action end to end (before or after this change), so I added a kill round-trip to the remote suite: start the fixture service, SIGKILL it through the UI, assert it lands in failed state with `MainPID` cleared. Verified against the ubuntu-24.04 matrix container, 80/80 checks. While writing that test I found a pre-existing bug: the declared `k` shortcut on the Kill and SIGKILL menu items was unreachable because `k` is bound to move-selection-up first — the menu displayed a shortcut that silently did something else. Fixed here by reassigning: Kill is now `K` and SIGKILL is `9` (as in `kill -9`). I kept `j`/`k` navigation as-is rather than letting shortcuts win, because a nav key that instantly sends SIGKILL in the signal menu seemed like a foot-gun. The round-trip test exercises the new shortcuts directly.




