### PR TITLE
Fix ARM `.deb` builds by skipping strip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,10 @@ jobs:
         with:
           tool: cargo-deb
       - name: Build .deb
-        run: cargo deb --target ${{ matrix.target }} --output .
+        # --no-strip: cargo-deb strips by default with the host `strip`, which
+        # chokes on aarch64 binaries. We don't strip release binaries anyway
+        # (see Cargo.toml), so skip it for both targets.
+        run: cargo deb --target ${{ matrix.target }} --output . --no-strip
       - name: Upload .deb to release
         run: gh release upload "$GITHUB_REF_NAME" ./*.deb
         env:


### PR DESCRIPTION
The aarch64 `.deb` job failed on the v0.7.0-test1 release: cargo-deb strips binaries by default using the host `strip`, which cannot read aarch64 ELF files.

```
strip: Unable to recognise the format of the input file '.../aarch64-unknown-linux-musl/release/systemctl-tui'
```

Fix is to pass `--no-strip` for both targets. We deliberately don't strip release binaries anyway (see the commented-out `strip` in `Cargo.toml`'s release profile), so the x86 deb getting stripped before was the inconsistency, not the ARM one failing.

Verified locally that `cargo deb --no-strip` builds the x86 package fine. The ARM build already compiled and linked in CI — it only died at the strip step, which this removes.