### PR TITLE
Bump `actions/checkout` to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -82,7 +82,7 @@ jobs:
         distro: [rocky-8, ubuntu-20.04, ubuntu-22.04, debian-12, ubuntu-24.04, fedora-latest, no-systemd, dead-systemd]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
             os: ubuntu-24.04
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
@@ -33,7 +33,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}


### PR DESCRIPTION
Every CI/release job has been logging a warning because checkout v4 targets Node 20, [which GitHub deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). v5 runs on Node 24. No functional changes.

The other actions we use (taiki-e/*, dtolnay/rust-toolchain, Swatinem/rust-cache) weren't named in the warnings, so I left them alone.